### PR TITLE
fix missing justify member

### DIFF
--- a/src/rmkit/ui/text.cpy
+++ b/src/rmkit/ui/text.cpy
@@ -15,6 +15,7 @@ namespace ui:
     enum JUSTIFY { LEFT, CENTER, RIGHT }
     static JUSTIFY DEFAULT_JUSTIFY
     static int DEFAULT_FS
+    JUSTIFY justify
     int font_size
     string text
 


### PR DESCRIPTION
Was getting a compilation error due to a missing declaration in text.cpy:

```
[evan@blackbox rmkit] ARCH=x86 make rmkit.h
mkdir src/build > /dev/null || true
mkdir: cannot create directory ‘src/build’: File exists
cd src/rmkit && make
make[1]: Entering directory '/home/evan/resources/rmkit/src/rmkit'
# $ARCH is x86
make compile_x86
make[2]: Entering directory '/home/evan/resources/rmkit/src/rmkit'
okp -sh -ni -for -d ../.rmkit.h_cpp/ -o ../build/rmkit.h rmkit.cpy -- -pthread -lpthread -DRMKIT_BUILD=1 -O0 -g
compile flags: -pthread -lpthread -DRMKIT_BUILD=1 -O0 -g
g++ -c /home/evan/resources/rmkit/src/.rmkit.h_cpp/rmkit.cpp -o /home/evan/resources/rmkit/src/.rmkit.h_cpp/rmkit.o -pthread -lpthread -DRMKIT_BUILD=1 -O0 -g
In file included from /home/evan/resources/rmkit/src/rmkit/ui/pixmap.cpy:3,
                 from /home/evan/resources/rmkit/src/rmkit/ui/button.cpy:2,
                 from /home/evan/resources/rmkit/src/rmkit/ui/ui.cpy:3,
                 from /home/evan/resources/rmkit/src/rmkit/rmkit.cpy:4:
/home/evan/resources/rmkit/src/rmkit/ui/text.cpy: In constructor ‘ui::Text::Text(int, int, int, int, std::string)’:
/home/evan/resources/rmkit/src/rmkit/ui/text.cpy:32:13: error: ‘class ui::Text’ has no member named ‘justify’
   32 |       self.justify = DEFAULT_JUSTIFY
      |             ^~~~~~~
/home/evan/resources/rmkit/src/rmkit/ui/text.cpy: In member function ‘virtual void ui::Text::render()’:
/home/evan/resources/rmkit/src/rmkit/ui/text.cpy:49:21: error: ‘class ui::Text’ has no member named ‘justify’
   49 |       switch self.justify:
      |                     ^~~~~~ 
In file included from /home/evan/resources/rmkit/src/rmkit/ui/ui.cpy:3,
                 from /home/evan/resources/rmkit/src/rmkit/rmkit.cpy:4:
/home/evan/resources/rmkit/src/rmkit/ui/button.cpy: In member function ‘void ui::Button::set_justification(ui::Text::JUSTIFY)’:
/home/evan/resources/rmkit/src/rmkit/ui/button.cpy:72:25: error: ‘using element_type = class ui::Text’ {aka ‘class ui::Text’} has no member named ‘justify’
   72 |       self.textWidget->justify = j
      |                         ^~~~~~~
In file included from /home/evan/resources/rmkit/src/rmkit/ui/ui.cpy:5,
                 from /home/evan/resources/rmkit/src/rmkit/rmkit.cpy:4:
/home/evan/resources/rmkit/src/rmkit/ui/dropdown.cpy: In constructor ‘ui::OptionSection::OptionSection(int, int, int, int, std::string)’:
/home/evan/resources/rmkit/src/rmkit/ui/dropdown.cpy:12:25: error: ‘using element_type = class ui::Text’ {aka ‘class ui::Text’} has no member named ‘justify’
   12 |       self.textWidget->justify = ui::Text::JUSTIFY::CENTER
      |                         ^~~~~~~
In file included from /home/evan/resources/rmkit/src/rmkit/ui/ui.cpy:14,
                 from /home/evan/resources/rmkit/src/rmkit/rmkit.cpy:4:
/home/evan/resources/rmkit/src/rmkit/ui/text_input.cpy: In constructor ‘ui::TextInput::TextInput(int, int, int, int, std::string)’:
/home/evan/resources/rmkit/src/rmkit/ui/text_input.cpy:21:13: error: ‘class ui::TextInput’ has no member named ‘justify’
   21 |       self.justify = ui::Text::JUSTIFY::CENTER
      |             ^~~~~~~
Couldn't compile /home/evan/resources/rmkit/src/.rmkit.h_cpp/rmkit.cpp aborting
compiled into /home/evan/resources/rmkit/src/.rmkit.h_cpp
make[2]: *** [../actions.make:39: compile_x86] Error 1
make[2]: Leaving directory '/home/evan/resources/rmkit/src/rmkit'
make[1]: *** [../actions.make:8: compile] Error 2
make[1]: Leaving directory '/home/evan/resources/rmkit/src/rmkit'
make: *** [Makefile:56: rmkit.h] Error 2
```