### PR TITLE
Add timeout_ms to ui::MainLoop::read_input()

### DIFF
--- a/src/rmkit/input/input.cpy
+++ b/src/rmkit/input/input.cpy
@@ -191,14 +191,19 @@ namespace input:
         ioctl(fd, EVIOCGRAB, false)
 
 
-    void listen_all():
+    void listen_all(long timeout_ms = 0):
       fd_set rdfs_cp
       int retval
       self.reset_events()
 
       rdfs_cp = rdfs
 
-      retval = select(max_fd, &rdfs_cp, NULL, NULL, NULL)
+      if timeout_ms > 0:
+          struct timeval tv = {timeout_ms / 1000, (timeout_ms % 1000) * 1000}
+          retval = select(max_fd, &rdfs_cp, NULL, NULL, &tv)
+      else:
+          retval = select(max_fd, &rdfs_cp, NULL, NULL, NULL)
+
       if retval > 0:
         if FD_ISSET(self.mouse.fd, &rdfs_cp):
           self.mouse.handle_mouse_fd()

--- a/src/rmkit/ui/main_loop.cpy
+++ b/src/rmkit/ui/main_loop.cpy
@@ -180,8 +180,8 @@ namespace ui:
 
 
     /// blocking read for input
-    static void read_input():
-      in.listen_all()
+    static void read_input(long timeout_ms = 0):
+      in.listen_all(timeout_ms)
 
     /// queue a render for all the widgets on the visible scenes
     static void refresh():


### PR DESCRIPTION
I need a very simple timer, which I could do with a separate thread, but IMO it's a little simpler in this case to think of the timer as another "input". Happy to rethink if you don't like this idea. Code isn't up yet in remarkable_puzzles, but I can put it on a branch later today.