### PR TITLE
Make FB destructors virtual

### DIFF
--- a/src/rmkit/fb/fb.cpy
+++ b/src/rmkit/fb/fb.cpy
@@ -94,7 +94,7 @@ namespace framebuffer:
       fprintf(stderr, "COPY CONSTRUCTOR CALLED\n")
       throw
 
-    ~FB():
+    virtual ~FB():
       if self.fd != -1:
         close(self.fd)
 
@@ -632,7 +632,7 @@ namespace framebuffer:
       if not exists:
         memset(self.fbmem, WHITE, self.byte_size)
 
-    ~FileFB():
+    virtual ~FileFB():
       msync(self.fbmem, self.byte_size, MS_ASYNC)
 
     int perform_redraw(bool):


### PR DESCRIPTION
I don't see any obvious immediate harm from having `~FB()` not virtual, but this makes it more natural to use a plain `FB *` pointer without specifying the concrete type.

This should also silence the warning I get trying to delete any FB subclass, e.g. 
```
warning: deleting object of polymorphic class type 'framebuffer::VirtualFB' which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]
```