### PR TITLE
[nao] Make opkg (or any other cmd) prefer the bins from `/opt/bin`

### DIFF
--- a/src/nao/nao.sh
+++ b/src/nao/nao.sh
@@ -40,7 +40,7 @@ function run_cmd() {
     outfile="/home/root/.cache/nao/output"
     errfile="/home/root/.cache/nao/errors"
     mkdir -p /home/root/.cache/nao/ 2>/dev/null
-    PATH="/opt/bin:$PATH" ${cmd} > "${outfile}" 2> "${errfile}" &
+    LD_PRELOAD= PATH="/opt/bin:$PATH" ${cmd} > "${outfile}" 2> "${errfile}" &
     pid="$!"
     output=`cat "${outfile}" | tail -n50`
     while   ps | grep -v grep | grep " $pid "

--- a/src/nao/nao.sh
+++ b/src/nao/nao.sh
@@ -40,7 +40,7 @@ function run_cmd() {
     outfile="/home/root/.cache/nao/output"
     errfile="/home/root/.cache/nao/errors"
     mkdir -p /home/root/.cache/nao/ 2>/dev/null
-    ${cmd} > "${outfile}" 2> "${errfile}" &
+    PATH="/opt/bin:$PATH" ${cmd} > "${outfile}" 2> "${errfile}" &
     pid="$!"
     output=`cat "${outfile}" | tail -n50`
     while   ps | grep -v grep | grep " $pid "


### PR DESCRIPTION
This should make opkg in nao use toltecs wget over the built-in/legacy one.

I have not tested it on device yet but did an isolated test of the change. I'm 99% sure that this works. Probably give it a quick test though.