### PR TITLE
add TextStyle object

### DIFF
--- a/src/harmony/app/ui.cpy
+++ b/src/harmony/app/ui.cpy
@@ -258,7 +258,7 @@ namespace app_ui:
   class Clock: public ui::Text:
     public:
     Clock(int x, y, w, h): Text(x,y,w,h,"clock"):
-      self.justify = ui::Text::JUSTIFY::CENTER
+      self.style.justify = ui::TextStyle::JUSTIFY::CENTER
 
     void before_render():
       time_t rawtime;

--- a/src/harmony/app/ui.cpy
+++ b/src/harmony/app/ui.cpy
@@ -258,7 +258,7 @@ namespace app_ui:
   class Clock: public ui::Text:
     public:
     Clock(int x, y, w, h): Text(x,y,w,h,"clock"):
-      self.style.justify = ui::TextStyle::JUSTIFY::CENTER
+      self.style->justify = ui::TextStyle::JUSTIFY::CENTER
 
     void before_render():
       time_t rawtime;

--- a/src/minesweeper/main.cpy
+++ b/src/minesweeper/main.cpy
@@ -42,7 +42,7 @@ class SizeButton: public ui::Button:
   public:
   int n
   SizeButton(int x, y, w, h, n, string t=""): n(n), Button(x,y,w,h,t):
-    self.textWidget->style.font_size = SIZE_BUTTON_FS
+    self.style->font_size = SIZE_BUTTON_FS
 
   void on_mouse_click(input::SynMotionEvent &ev):
     if GRID_SIZE != n:
@@ -57,7 +57,7 @@ class SizeButton: public ui::Button:
 class ScoresButton: public ui::Button:
   public:
   ScoresButton(int x, y, w, h, string t="HIGH SCORES") : Button(x,y,w,h,t):
-    self.textWidget->style.font_size = SIZE_BUTTON_FS
+    self.style->font_size = SIZE_BUTTON_FS
 
   void on_mouse_click(input::SynMotionEvent &ev):
     show_scores()
@@ -106,7 +106,7 @@ class Cell: public ui::Widget:
 
   Cell(int x, y, w, h, IGrid *g, int i, j): grid(g), i(i), j(j), Widget(x, y, w, h):
     self.textWidget = new ui::Text(x, y, w, h, "")
-    self.textWidget->style.justify = ui::TextStyle::JUSTIFY::CENTER
+    self.style->justify = ui::TextStyle::JUSTIFY::CENTER
 
   void reset():
     self.flagged = 0
@@ -357,7 +357,7 @@ class HighScoreWidget: public ui::Widget:
 
   void render():
     text := ui::Text(self.x, self.y, 800, 500, "under construction")
-    text.style.justify = ui::TextStyle::JUSTIFY::CENTER
+    text.style->justify = ui::TextStyle::JUSTIFY::CENTER
     text.render()
 
 class App:
@@ -381,7 +381,7 @@ class App:
 
     image := stbtext::get_text_size("MineSweeper", 64)
     text := new ui::Text(0, 0, image.w, 50, "MineSweeper")
-    text->style.font_size = 64
+    text->style->font_size = 64
     h_layout.pack_center(text)
 
     size_button_container := ui::VerticalLayout(0, 0, 800, 200*5, title_menu)
@@ -442,7 +442,7 @@ class App:
 
     h_layout := ui::HorizontalLayout(0, 0, w, h, field_scene)
     text := new ui::Text(0, 0, w, 50, "MineSweeper")
-    text->style.font_size = SIZE_BUTTON_FS
+    text->style->font_size = SIZE_BUTTON_FS
     h_layout.pack_center(text)
     h_layout.pack_center(grid)
     // pack cells after centering grid

--- a/src/minesweeper/main.cpy
+++ b/src/minesweeper/main.cpy
@@ -42,7 +42,7 @@ class SizeButton: public ui::Button:
   public:
   int n
   SizeButton(int x, y, w, h, n, string t=""): n(n), Button(x,y,w,h,t):
-    self.textWidget->font_size = SIZE_BUTTON_FS
+    self.textWidget->style.font_size = SIZE_BUTTON_FS
 
   void on_mouse_click(input::SynMotionEvent &ev):
     if GRID_SIZE != n:
@@ -57,7 +57,7 @@ class SizeButton: public ui::Button:
 class ScoresButton: public ui::Button:
   public:
   ScoresButton(int x, y, w, h, string t="HIGH SCORES") : Button(x,y,w,h,t):
-    self.textWidget->font_size = SIZE_BUTTON_FS
+    self.textWidget->style.font_size = SIZE_BUTTON_FS
 
   void on_mouse_click(input::SynMotionEvent &ev):
     show_scores()
@@ -106,7 +106,7 @@ class Cell: public ui::Widget:
 
   Cell(int x, y, w, h, IGrid *g, int i, j): grid(g), i(i), j(j), Widget(x, y, w, h):
     self.textWidget = new ui::Text(x, y, w, h, "")
-    self.textWidget->justify = ui::Text::JUSTIFY::CENTER
+    self.textWidget->style.justify = ui::TextStyle::JUSTIFY::CENTER
 
   void reset():
     self.flagged = 0
@@ -357,7 +357,7 @@ class HighScoreWidget: public ui::Widget:
 
   void render():
     text := ui::Text(self.x, self.y, 800, 500, "under construction")
-    text.justify = ui::Text::JUSTIFY::CENTER
+    text.style.justify = ui::TextStyle::JUSTIFY::CENTER
     text.render()
 
 class App:
@@ -381,7 +381,7 @@ class App:
 
     image := stbtext::get_text_size("MineSweeper", 64)
     text := new ui::Text(0, 0, image.w, 50, "MineSweeper")
-    text->font_size = 64
+    text->style.font_size = 64
     h_layout.pack_center(text)
 
     size_button_container := ui::VerticalLayout(0, 0, 800, 200*5, title_menu)
@@ -390,7 +390,7 @@ class App:
     button_height := 200
     for auto p : sizes:
       btn := new SizeButton(w/2-400, 500, 800, button_height, p.first, p.second)
-      btn->set_justification(ui::Text::JUSTIFY::CENTER)
+      btn->set_justification(ui::TextStyle::JUSTIFY::CENTER)
       btn->y_padding = (button_height - SIZE_BUTTON_FS) / 2
       size_button_container.pack_start(btn)
       debug "BTN", btn->x, btn->y
@@ -401,7 +401,7 @@ class App:
 //    size_button_container.pack_start(new SizeButton(w/2-400, 50, 800, 200, 20, "20x20"))
 
     scores := new ScoresButton(w/2-400, 500, 800, button_height)
-    scores->set_justification(ui::Text::JUSTIFY::CENTER)
+    scores->set_justification(ui::TextStyle::JUSTIFY::CENTER)
     scores->y_padding = (button_height - SIZE_BUTTON_FS) / 2
     debug scores->x, scores->y
     size_button_container.pack_start(scores)
@@ -442,7 +442,7 @@ class App:
 
     h_layout := ui::HorizontalLayout(0, 0, w, h, field_scene)
     text := new ui::Text(0, 0, w, 50, "MineSweeper")
-    text->font_size = SIZE_BUTTON_FS
+    text->style.font_size = SIZE_BUTTON_FS
     h_layout.pack_center(text)
     h_layout.pack_center(grid)
     // pack cells after centering grid
@@ -544,7 +544,7 @@ void show_scores():
   ui::MainLoop::refresh()
 
 def main():
-  ui::Text::DEFAULT_FS = 32
+  ui::TextStyle::DEFAULT_FS = 32
   app.run()
 
 // vim:syntax=cpp

--- a/src/remux/launcher.cpy
+++ b/src/remux/launcher.cpy
@@ -164,7 +164,7 @@ class AppDialog: public ui::Pager:
 
         cw := 350
         b3 := new StatusBar(self.x+self.w-cw, self.y-50, cw, 50, stat_str)
-        b3->set_justification(ui::Text::JUSTIFY::RIGHT)
+        b3->set_justification(ui::TextStyle::JUSTIFY::RIGHT)
         self.scene->add(b3)
 
 
@@ -210,11 +210,11 @@ class AppDialog: public ui::Pager:
             c->dirty = 1
         }
 
-      c->set_justification(ui::Text::JUSTIFY::RIGHT)
+      c->set_justification(ui::TextStyle::JUSTIFY::RIGHT)
       d := new ui::DialogButton(0, 0, self.w-90, self.opt_h, self, option)
       d->x_padding = 10
       d->y_padding = 5
-      d->set_justification(ui::Text::JUSTIFY::LEFT)
+      d->set_justification(ui::TextStyle::JUSTIFY::LEFT)
       self.layout->pack_start(row)
       row->pack_start(d)
       row->pack_end(c)
@@ -504,7 +504,7 @@ class App: public IApp:
     #else
     text := ui::Text(0, _h-64, _w, 100, "Press any button to wake")
     text.font_size = 64
-    text.justify = ui::Text::JUSTIFY::CENTER
+    text.justify = ui::TextStyle::JUSTIFY::CENTER
 
     text.undraw()
     text.render()
@@ -759,7 +759,7 @@ class App: public IApp:
     proc::launch_process(xochitl_cmd, true /* check running */, true /* background */)
     #endif
 
-    ui::Text::DEFAULT_FS = 32
+    ui::TextStyle::DEFAULT_FS = 32
 
     // launches a thread that suspends on idle
     self.suspend_on_idle()

--- a/src/rmkit/ui/button.cpy
+++ b/src/rmkit/ui/button.cpy
@@ -38,7 +38,7 @@ namespace ui:
       Button::key_ctr++
       self.text = t
       self.textWidget = make_shared<Text>(x, y, w, h, t)
-      self.set_justification(ui::Text::JUSTIFY::CENTER)
+      self.set_justification(ui::TextStyle::JUSTIFY::CENTER)
       #ifdef DEV
       debug self.text, "=", input::get_key_str(self.key)
       #endif
@@ -69,8 +69,8 @@ namespace ui:
     //
     //      sets the alignment of the text of the button. j is one of ::LEFT,
     //      ::CENTER or ::RIGHT
-    void set_justification(Text::JUSTIFY j):
-      self.textWidget->justify = j
+    void set_justification(TextStyle::JUSTIFY j):
+      self.textWidget->style.justify = j
 
     void before_render():
       has_icon := false

--- a/src/rmkit/ui/button.cpy
+++ b/src/rmkit/ui/button.cpy
@@ -38,7 +38,9 @@ namespace ui:
       Button::key_ctr++
       self.text = t
       self.textWidget = make_shared<Text>(x, y, w, h, t)
-      self.set_justification(ui::TextStyle::JUSTIFY::CENTER)
+      self.textWidget->style = self.style // link our styles to the textWidget
+
+      self.style->justify = ui::TextStyle::JUSTIFY::CENTER
       #ifdef DEV
       debug self.text, "=", input::get_key_str(self.key)
       #endif
@@ -70,7 +72,7 @@ namespace ui:
     //      sets the alignment of the text of the button. j is one of ::LEFT,
     //      ::CENTER or ::RIGHT
     void set_justification(TextStyle::JUSTIFY j):
-      self.textWidget->style.justify = j
+      self.style->justify = j
 
     void before_render():
       has_icon := false

--- a/src/rmkit/ui/dialog.cpy
+++ b/src/rmkit/ui/dialog.cpy
@@ -90,9 +90,9 @@ namespace ui:
 
     virtual void add_buttons(HorizontalLayout *button_bar):
       for auto b : self.buttons:
-        image := stbtext::get_text_size(b, ui::Text::DEFAULT_FS)
+        image := stbtext::get_text_size(b, ui::TextStyle::DEFAULT_FS)
 
-        button_bar->pack_start(new DialogButton(20, 0, image.w + ui::Text::DEFAULT_FS, 50, self, b))
+        button_bar->pack_start(new DialogButton(20, 0, image.w + ui::TextStyle::DEFAULT_FS, 50, self, b))
 
     // function: on_button_selected
     // this is called when the dialog's buttons are pressed

--- a/src/rmkit/ui/dropdown.cpy
+++ b/src/rmkit/ui/dropdown.cpy
@@ -9,7 +9,7 @@ namespace ui:
 
     OptionSection(int x, y, w, h, string t): ui::Button(x,y,w,h,t):
       self.mouse_inside = true
-      self.textWidget->justify = ui::Text::JUSTIFY::CENTER
+      self.textWidget->style.justify = ui::TextStyle::JUSTIFY::CENTER
 
     bool ignore_event(input::SynMotionEvent &ev):
       return true
@@ -27,7 +27,7 @@ namespace ui:
     OptionButton(int x, y, w, h, IOptionButton* tb, string text, int idx): \
                  tb(tb), text(text), idx(idx), ui::Button(x,y,w,h,text):
       self.x_padding = 10
-      self.set_justification(ui::Text::JUSTIFY::LEFT)
+      self.set_justification(ui::TextStyle::JUSTIFY::LEFT)
 
     void on_mouse_click(input::SynMotionEvent &ev):
       self.tb->select(self.idx)

--- a/src/rmkit/ui/dropdown.cpy
+++ b/src/rmkit/ui/dropdown.cpy
@@ -9,7 +9,7 @@ namespace ui:
 
     OptionSection(int x, y, w, h, string t): ui::Button(x,y,w,h,t):
       self.mouse_inside = true
-      self.textWidget->style.justify = ui::TextStyle::JUSTIFY::CENTER
+      self.style->justify = ui::TextStyle::JUSTIFY::CENTER
 
     bool ignore_event(input::SynMotionEvent &ev):
       return true

--- a/src/rmkit/ui/keyboard.cpy
+++ b/src/rmkit/ui/keyboard.cpy
@@ -129,7 +129,7 @@ namespace ui:
       v_layout := ui::VerticalLayout(0, 0, fw, fh, self.scene)
 
       self.input_box = new MultiText(0,0,w,50,self.text)
-      self.input_box->font_size = 64
+      self.input_box->style.font_size = 64
       v_layout.pack_start(input_box)
 
       v_layout.pack_end(row4)
@@ -144,7 +144,7 @@ namespace ui:
         row2->add_key(self.make_char_button(c))
 
       shift_key := new KeyButton(0, 0, self.btn_width, btn_height, "shift")
-      shift_key->textWidget->font_size = btn_font_size
+      shift_key->textWidget->style.font_size = btn_font_size
       shift_key->mouse.click += PLS_LAMBDA(auto &ev):
         if !numbers and !shifted:
           self.upper_layout()
@@ -159,7 +159,7 @@ namespace ui:
       for (auto c: row3chars):
         row3->add_key(self.make_char_button(c))
       backspace_key := new KeyButton(0,0,self.btn_width,btn_height,"back")
-      backspace_key->textWidget->font_size = btn_font_size
+      backspace_key->textWidget->style.font_size = btn_font_size
 
 
       backspace_key->mouse.click += PLS_LAMBDA(auto &ev):
@@ -179,7 +179,7 @@ namespace ui:
           self.number_layout()
       ;
       space_key := new KeyButton(0,0,self.btn_width*8,btn_height,"space")
-      space_key->textWidget->font_size = btn_font_size
+      space_key->textWidget->style.font_size = btn_font_size
       space_key->mouse.click += PLS_LAMBDA(auto &ev):
         self.text += " "
         self.input_box->text = text
@@ -188,7 +188,7 @@ namespace ui:
       ;
 
       enter_key := new KeyButton(0,0,self.btn_width,btn_height,"done")
-      enter_key->textWidget->font_size = btn_font_size
+      enter_key->textWidget->style.font_size = btn_font_size
       enter_key->mouse.click += PLS_LAMBDA(auto &ev):
         self.hide()
         ui::MainLoop::refresh()
@@ -212,7 +212,7 @@ namespace ui:
     KeyButton* make_char_button(char c):
       string s(1, c)
       key := new KeyButton(0,0,self.btn_width,btn_height,s)
-      key->textWidget->font_size = btn_font_size
+      key->textWidget->style.font_size = btn_font_size
       key->mouse.click += PLS_LAMBDA(auto &ev):
         self.dirty = 1
         if c == ' ':

--- a/src/rmkit/ui/keyboard.cpy
+++ b/src/rmkit/ui/keyboard.cpy
@@ -129,7 +129,7 @@ namespace ui:
       v_layout := ui::VerticalLayout(0, 0, fw, fh, self.scene)
 
       self.input_box = new MultiText(0,0,w,50,self.text)
-      self.input_box->style.font_size = 64
+      self.input_box->style->font_size = 64
       v_layout.pack_start(input_box)
 
       v_layout.pack_end(row4)
@@ -144,7 +144,7 @@ namespace ui:
         row2->add_key(self.make_char_button(c))
 
       shift_key := new KeyButton(0, 0, self.btn_width, btn_height, "shift")
-      shift_key->textWidget->style.font_size = btn_font_size
+      shift_key->style->font_size = btn_font_size
       shift_key->mouse.click += PLS_LAMBDA(auto &ev):
         if !numbers and !shifted:
           self.upper_layout()
@@ -159,7 +159,7 @@ namespace ui:
       for (auto c: row3chars):
         row3->add_key(self.make_char_button(c))
       backspace_key := new KeyButton(0,0,self.btn_width,btn_height,"back")
-      backspace_key->textWidget->style.font_size = btn_font_size
+      backspace_key->style->font_size = btn_font_size
 
 
       backspace_key->mouse.click += PLS_LAMBDA(auto &ev):
@@ -179,7 +179,7 @@ namespace ui:
           self.number_layout()
       ;
       space_key := new KeyButton(0,0,self.btn_width*8,btn_height,"space")
-      space_key->textWidget->style.font_size = btn_font_size
+      space_key->style->font_size = btn_font_size
       space_key->mouse.click += PLS_LAMBDA(auto &ev):
         self.text += " "
         self.input_box->text = text
@@ -188,7 +188,7 @@ namespace ui:
       ;
 
       enter_key := new KeyButton(0,0,self.btn_width,btn_height,"done")
-      enter_key->textWidget->style.font_size = btn_font_size
+      enter_key->style->font_size = btn_font_size
       enter_key->mouse.click += PLS_LAMBDA(auto &ev):
         self.hide()
         ui::MainLoop::refresh()
@@ -212,7 +212,7 @@ namespace ui:
     KeyButton* make_char_button(char c):
       string s(1, c)
       key := new KeyButton(0,0,self.btn_width,btn_height,s)
-      key->textWidget->style.font_size = btn_font_size
+      key->style->font_size = btn_font_size
       key->mouse.click += PLS_LAMBDA(auto &ev):
         self.dirty = 1
         if c == ' ':

--- a/src/rmkit/ui/pager.cpy
+++ b/src/rmkit/ui/pager.cpy
@@ -41,7 +41,7 @@ namespace ui:
 
     virtual void render_row(ui::HorizontalLayout *row, string option):
       d := new ui::DialogButton(20,0, self.w-80, self.opt_h, self, option)
-      d->set_justification(ui::Text::JUSTIFY::LEFT)
+      d->set_justification(ui::TextStyle::JUSTIFY::LEFT)
       layout->pack_start(d)
 
     void setup_for_render(int page=0):

--- a/src/rmkit/ui/text.cpy
+++ b/src/rmkit/ui/text.cpy
@@ -10,8 +10,6 @@ namespace ui:
   // the ui::Text class is a Widget that can render a single line of text.
   class Text: public Widget:
     public:
-    TextStyle style
-
     string text
     bool underline = false
 
@@ -29,12 +27,12 @@ namespace ui:
 
 
     tuple<int, int> get_render_size():
-      image := stbtext::get_text_size(self.text, self.style.font_size)
+      image := stbtext::get_text_size(self.text, self.style->font_size)
       return image.w, image.h
 
     // TODO: cache the image buffer
     void render():
-      font_size := style.font_size
+      font_size := style->font_size
       image := stbtext::get_text_size(self.text, font_size)
 
       image.buffer = (uint32_t*) malloc(sizeof(uint32_t) * image.w * image.h)
@@ -43,7 +41,7 @@ namespace ui:
       leftover_x := self.w - image.w
       padding_x := 0
 
-      switch self.style.justify:
+      switch self.style->justify:
         case TextStyle::JUSTIFY::CENTER:
           if leftover_x > 0:
             padding_x = leftover_x / 2
@@ -86,7 +84,7 @@ namespace ui:
       cur_x := 0
       cur_y := 0
       lines := split(self.text, '\n')
-      font_size := style.font_size
+      font_size := style->font_size
       for auto line: lines:
         cur_x = 0
         tokens := split(line, ' ')
@@ -120,7 +118,7 @@ namespace ui:
         int max_h = 0
         for auto w: tokens:
           w += " "
-          image := stbtext::get_text_size(w, self.style.font_size)
+          image := stbtext::get_text_size(w, self.style->font_size)
           max_h = max(image.h, max_h)
           if cur_x + image.w + 10 >= self.w:
             cur_x = 0

--- a/src/rmkit/ui/text.cpy
+++ b/src/rmkit/ui/text.cpy
@@ -10,15 +10,11 @@ namespace ui:
   // the ui::Text class is a Widget that can render a single line of text.
   class Text: public Widget:
     public:
+    TextStyle style
 
-    // function: Text Dropdown
-    enum JUSTIFY { LEFT, CENTER, RIGHT }
-    static JUSTIFY DEFAULT_JUSTIFY
-    static int DEFAULT_FS
-    int font_size
     string text
     bool underline = false
-    JUSTIFY justify
+
 
     // function: Constructor
     // parameters:
@@ -30,17 +26,16 @@ namespace ui:
     // t - the text to render in the widget
     Text(int x, y, w, h, string t): Widget(x, y, w, h):
       self.text = t
-      self.font_size = DEFAULT_FS
-      self.justify = DEFAULT_JUSTIFY
 
 
     tuple<int, int> get_render_size():
-      image := stbtext::get_text_size(self.text, self.font_size)
+      image := stbtext::get_text_size(self.text, self.style.font_size)
       return image.w, image.h
 
     // TODO: cache the image buffer
     void render():
-      image := stbtext::get_text_size(self.text, self.font_size)
+      font_size := style.font_size
+      image := stbtext::get_text_size(self.text, font_size)
 
       image.buffer = (uint32_t*) malloc(sizeof(uint32_t) * image.w * image.h)
       memset(image.buffer, WHITE, sizeof(uint32_t) * image.w * image.h)
@@ -48,17 +43,17 @@ namespace ui:
       leftover_x := self.w - image.w
       padding_x := 0
 
-      switch self.justify:
-        case JUSTIFY::CENTER:
+      switch self.style.justify:
+        case TextStyle::JUSTIFY::CENTER:
           if leftover_x > 0:
             padding_x = leftover_x / 2
           break
-        case JUSTIFY::RIGHT:
+        case TextStyle::JUSTIFY::RIGHT:
           if leftover_x > 0:
             padding_x = leftover_x
           break
 
-      fb->draw_text(self.text, self.x + padding_x, self.y, image, self.font_size)
+      fb->draw_text(self.text, self.x + padding_x, self.y, image, font_size)
       if self.underline:
         fb->draw_line(self.x+padding_x, self.y+font_size, self.x+padding_x+image.w-font_size,
                       self.y+font_size, 1, BLACK)
@@ -91,20 +86,21 @@ namespace ui:
       cur_x := 0
       cur_y := 0
       lines := split(self.text, '\n')
+      font_size := style.font_size
       for auto line: lines:
         cur_x = 0
         tokens := split(line, ' ')
         int max_h = 0
         for auto w: tokens:
           w += " "
-          image := stbtext::get_text_size(w, self.font_size)
+          image := stbtext::get_text_size(w, font_size)
           image.buffer = (uint32_t*) malloc(sizeof(uint32_t) * image.w * image.h)
           max_h = max(image.h, max_h)
           memset(image.buffer, WHITE, sizeof(uint32_t) * image.w * image.h)
           if cur_x + image.w + 10 >= self.w:
             cur_x = 0
             cur_y += max_h
-          self.fb->draw_text(w, self.x + cur_x, self.y + cur_y, image, self.font_size)
+          self.fb->draw_text(w, self.x + cur_x, self.y + cur_y, image, font_size)
           if self.underline:
             self.fb->draw_line(self.x+cur_x, self.y+cur_y+font_size, self.x+cur_x+image.w,
                                self.y + cur_y+font_size, 1, BLACK)
@@ -124,7 +120,7 @@ namespace ui:
         int max_h = 0
         for auto w: tokens:
           w += " "
-          image := stbtext::get_text_size(w, self.font_size)
+          image := stbtext::get_text_size(w, self.style.font_size)
           max_h = max(image.h, max_h)
           if cur_x + image.w + 10 >= self.w:
             cur_x = 0
@@ -137,5 +133,5 @@ namespace ui:
 
       return ret_w, ret_h
 
-  int Text::DEFAULT_FS = 24
-  Text::JUSTIFY Text::DEFAULT_JUSTIFY = ui::Text::JUSTIFY::CENTER
+  int TextStyle::DEFAULT_FS = 24
+  TextStyle::JUSTIFY TextStyle::DEFAULT_JUSTIFY = ui::TextStyle::JUSTIFY::CENTER

--- a/src/rmkit/ui/text_input.cpy
+++ b/src/rmkit/ui/text_input.cpy
@@ -28,7 +28,7 @@ namespace ui:
     // h - height
     // t - the content of the text input
     TextInput(int x, y, w, h, string t=""): ui::Text(x, y, w, h, t):
-      self.justify = ui::Text::JUSTIFY::CENTER
+      self.style.justify = ui::TextStyle::JUSTIFY::CENTER
 
     void on_mouse_click(input::SynMotionEvent &ev):
       keyboard := new ui::Keyboard()

--- a/src/rmkit/ui/text_input.cpy
+++ b/src/rmkit/ui/text_input.cpy
@@ -28,7 +28,7 @@ namespace ui:
     // h - height
     // t - the content of the text input
     TextInput(int x, y, w, h, string t=""): ui::Text(x, y, w, h, t):
-      self.style.justify = ui::TextStyle::JUSTIFY::CENTER
+      self.style->justify = ui::TextStyle::JUSTIFY::CENTER
 
     void on_mouse_click(input::SynMotionEvent &ev):
       keyboard := new ui::Keyboard()

--- a/src/rmkit/ui/widget.cpy
+++ b/src/rmkit/ui/widget.cpy
@@ -47,7 +47,7 @@ namespace ui:
     // should) draw directly to the framebuffer
     static framebuffer::FB *fb
     vector<shared_ptr<Widget>> children
-    TextStyle style
+    shared_ptr<TextStyle> style
 
     MOUSE_EVENTS mouse
     KEY_EVENTS kbd
@@ -74,6 +74,7 @@ namespace ui:
     // h - the height of the widget
     Widget(int x,y,w,h): x(x), y(y), w(w), h(h), _x(x), _y(y), _w(w), _h(h):
       self.install_signal_handlers()
+      self.style = make_shared<TextStyle>()
 
     // function: mark_redraw
     // marks this widget as needing to be redrawn during the next redraw cycle

--- a/src/rmkit/ui/widget.cpy
+++ b/src/rmkit/ui/widget.cpy
@@ -2,6 +2,21 @@
 #include "../util/signals.h"
 
 namespace ui:
+  class TextStyle:
+    public:
+    enum JUSTIFY { LEFT, CENTER, RIGHT }
+    static JUSTIFY DEFAULT_JUSTIFY
+    static int DEFAULT_FS
+
+    int font_size = DEFAULT_FS
+    bool underline = false
+    JUSTIFY justify
+
+    TextStyle():
+      self.font_size = TextStyle::DEFAULT_FS
+      self.justify = TextStyle::DEFAULT_JUSTIFY
+
+
   PLS_DEFINE_SIGNAL(MOUSE_EVENT, input::SynMotionEvent)
   class MOUSE_EVENTS:
     public:
@@ -32,6 +47,7 @@ namespace ui:
     // should) draw directly to the framebuffer
     static framebuffer::FB *fb
     vector<shared_ptr<Widget>> children
+    TextStyle style
 
     MOUSE_EVENTS mouse
     KEY_EVENTS kbd
@@ -191,6 +207,5 @@ namespace ui:
     // supplied text
     virtual tuple<int, int> get_render_size():
       return self.w, self.h
-
 
   framebuffer::FB* Widget::fb = NULL

--- a/src/sharenote/main.cpy
+++ b/src/sharenote/main.cpy
@@ -259,7 +259,7 @@ class App:
 
     erase_button := new EraseButton(0, 0, 200, 50)
     room_label := new ui::Text(0, 0, 200, 50, "room: ")
-    room_label->justify = ui::Text::JUSTIFY::RIGHT
+    room_label->style.justify = ui::TextStyle::JUSTIFY::RIGHT
     room_button := new RoomInput(0, 0, 200, 50, socket)
 
     button_bar->pack_start(erase_button)

--- a/src/sharenote/main.cpy
+++ b/src/sharenote/main.cpy
@@ -259,7 +259,7 @@ class App:
 
     erase_button := new EraseButton(0, 0, 200, 50)
     room_label := new ui::Text(0, 0, 200, 50, "room: ")
-    room_label->style.justify = ui::TextStyle::JUSTIFY::RIGHT
+    room_label->style->justify = ui::TextStyle::JUSTIFY::RIGHT
     room_button := new RoomInput(0, 0, 200, 50, socket)
 
     button_bar->pack_start(erase_button)

--- a/src/simple/main.cpy
+++ b/src/simple/main.cpy
@@ -3,7 +3,7 @@
 #include "../shared/string.h"
 using namespace std
 
-int FONT_SIZE = ui::Text::DEFAULT_FS
+int FONT_SIZE = ui::TextStyle::DEFAULT_FS
 WIDTH := 0
 HEIGHT := 0
 EXPECTING_INPUT := false
@@ -69,25 +69,25 @@ def dump_widgets(ui::Scene s):
     pass
 
 // directives
-int OLD_DEFAULT_FS = ui::Text::DEFAULT_FS
-int OLD_DEFAULT_JUSTIFY = ui::Text::DEFAULT_JUSTIFY
+int OLD_DEFAULT_FS = ui::TextStyle::DEFAULT_FS
+int OLD_DEFAULT_JUSTIFY = ui::TextStyle::DEFAULT_JUSTIFY
 int PADDING_X = 0
 int PADDING_Y = 0
 def handle_directive(int line_no, ui::Scene s, vector<string> &tokens):
   debug "HANDLING DIRECTIVE", tokens[0], tokens[1]
   if tokens[0] == "@fontsize":
-    ui::Text::DEFAULT_FS = stoi(tokens[1])
+    ui::TextStyle::DEFAULT_FS = stoi(tokens[1])
 
   if tokens[0] == "@noclear":
     CLEAR_SCREEN = false
 
   if tokens[0] == "@justify":
     if tokens[1] == "left":
-      ui::Text::DEFAULT_JUSTIFY = ui::Text::JUSTIFY::LEFT
+      ui::TextStyle::DEFAULT_JUSTIFY = ui::TextStyle::JUSTIFY::LEFT
     if tokens[1] == "center":
-      ui::Text::DEFAULT_JUSTIFY = ui::Text::JUSTIFY::CENTER
+      ui::TextStyle::DEFAULT_JUSTIFY = ui::TextStyle::JUSTIFY::CENTER
     if tokens[1] == "right":
-      ui::Text::DEFAULT_JUSTIFY = ui::Text::JUSTIFY::RIGHT
+      ui::TextStyle::DEFAULT_JUSTIFY = ui::TextStyle::JUSTIFY::RIGHT
 
   if tokens[0] == "@padding_x":
     PADDING_X = stoi(tokens[1])
@@ -175,7 +175,7 @@ bool handle_widget(int line_no, ui::Scene scene, vector<string> &tokens):
     else if first == "button":
       button := new ui::Button(x,y,w,h,t)
       widget := give_id(id, button)
-      button->set_justification(ui::Text::DEFAULT_JUSTIFY)
+      button->set_justification(ui::TextStyle::DEFAULT_JUSTIFY)
       button->underline = true
       scene->add(widget)
       EXPECTING_INPUT = true
@@ -191,7 +191,7 @@ bool handle_widget(int line_no, ui::Scene scene, vector<string> &tokens):
       ;
     else if first == "textinput":
       textinput := new ui::TextInput(x,y,w,h,t)
-      textinput->justify = ui::Text::DEFAULT_JUSTIFY
+      textinput->style.justify = ui::TextStyle::DEFAULT_JUSTIFY
       textinput->events.done += PLS_LAMBDA(string &s):
         debug "PRINTING REF", t, textinput->ref,  s
         if ref:

--- a/src/simple/main.cpy
+++ b/src/simple/main.cpy
@@ -191,7 +191,7 @@ bool handle_widget(int line_no, ui::Scene scene, vector<string> &tokens):
       ;
     else if first == "textinput":
       textinput := new ui::TextInput(x,y,w,h,t)
-      textinput->style.justify = ui::TextStyle::DEFAULT_JUSTIFY
+      textinput->style->justify = ui::TextStyle::DEFAULT_JUSTIFY
       textinput->events.done += PLS_LAMBDA(string &s):
         debug "PRINTING REF", t, textinput->ref,  s
         if ref:


### PR DESCRIPTION
based on https://github.com/rmkit-dev/rmkit/issues/50, this adds `shared_ptr<TextStyle> style` to all widgets. The style contains basic text styling information. By default buttons set their textWidget's `style` property to their own, thus linking their attributes. 

