### PR TITLE
Add valign and border styles

### DIFF
--- a/src/rmkit/ui/button.cpy
+++ b/src/rmkit/ui/button.cpy
@@ -46,7 +46,7 @@ namespace ui:
 
     void set_style(const Stylesheet & style):
       Widget::set_style(style)
-      self.textWidget->set_style(Stylesheet::Inherited(self.style).text_style())
+      self.textWidget->set_style(Stylesheet::Inherited(self.style).text_style().alignment())
 
     void on_mouse_move(input::SynMotionEvent &ev):
       ev.stop_propagation()
@@ -80,6 +80,9 @@ namespace ui:
         self.textWidget->text = text
         if text != "":
           has_text = true
+
+      if style.valign != Style::VALIGN::TOP:
+        y_padding = 0
 
       if has_icon && has_text:
         self.iconWidget->x = self.x + x_padding

--- a/src/rmkit/ui/scene.cpy
+++ b/src/rmkit/ui/scene.cpy
@@ -41,6 +41,7 @@ namespace ui:
 
         if widget->dirty:
           widget->render()
+          widget->render_border()
           widget->dirty = 0
 
         if widget->children.size():

--- a/src/rmkit/ui/style.h
+++ b/src/rmkit/ui/style.h
@@ -82,7 +82,7 @@ public:
     Stylesheet & font_size(short val) { return set(&Style::font_size, val); }
     Stylesheet & font_size(const Style & src) { return copy(&Style::font_size, src); }
 
-    Stylesheet & underline(bool val) { return set(&Style::underline, val); }
+    Stylesheet & underline(bool val=true) { return set(&Style::underline, val); }
     Stylesheet & underline(const Style & src) { return copy(&Style::underline, src); }
 
     Stylesheet & justify(Style::JUSTIFY val) { return set(&Style::justify, val); }

--- a/src/rmkit/ui/style.h
+++ b/src/rmkit/ui/style.h
@@ -16,7 +16,11 @@ struct Style {
     bool underline = DEFAULT.underline;
     JUSTIFY justify = DEFAULT.justify;
     VALIGN valign = DEFAULT.valign;
-    // TODO: border, background, padding
+    bool border_top = DEFAULT.border_top;
+    bool border_left = DEFAULT.border_left;
+    bool border_bottom = DEFAULT.border_bottom;
+    bool border_right = DEFAULT.border_right;
+    // TODO: background, padding
 
     static Style DEFAULT;
 };
@@ -97,6 +101,19 @@ public:
     Stylesheet & valign_middle() { return valign(Style::VALIGN::MIDDLE); }
     Stylesheet & valign_bottom() { return valign(Style::VALIGN::BOTTOM); }
 
+    Stylesheet & border_top(bool val=true) { return set(&Style::border_top, val); }
+    Stylesheet & border_left(bool val=true) { return set(&Style::border_left, val); }
+    Stylesheet & border_bottom(bool val=true) { return set(&Style::border_bottom, val); }
+    Stylesheet & border_right(bool val=true) { return set(&Style::border_right, val); }
+    Stylesheet & border_top(const Style & src) { return copy(&Style::border_top, src); }
+    Stylesheet & border_left(const Style & src) { return copy(&Style::border_left, src); }
+    Stylesheet & border_bottom(const Style & src) { return copy(&Style::border_bottom, src); }
+    Stylesheet & border_right(const Style & src) { return copy(&Style::border_right, src); }
+
+    Stylesheet & border_all(bool val=true) { return border_top(val).border_left(val).border_bottom(val).border_right(val); }
+    Stylesheet & border_none() { return border_all(false); }
+    Stylesheet & border(const Style & src) { return border_top(src).border_left(src).border_bottom(src).border_right(src); }
+
     // Shortcuts
     Stylesheet & text_style(const Style & src)
     {
@@ -131,6 +148,11 @@ public:
     Inherited & underline() { sheet.underline(src); return *this; }
     Inherited & justify() { sheet.justify(src); return *this; }
     Inherited & valign() { sheet.justify(src); return *this; }
+    Inherited & border() { sheet.border(src); return *this; }
+    Inherited & border_top() { sheet.border_top(src); return *this; }
+    Inherited & border_left() { sheet.border_left(src); return *this; }
+    Inherited & border_bottom() { sheet.border_bottom(src); return *this; }
+    Inherited & border_right() { sheet.border_right(src); return *this; }
     Inherited & text_style() { sheet.text_style(src); return *this; }
     Inherited & alignment() { sheet.alignment(src); return *this; }
 };
@@ -140,6 +162,7 @@ Style Style::DEFAULT = Stylesheet()
     .underline(false)
     .justify_center()
     .valign_top()
+    .border_none()
     .build();
 
 }

--- a/src/rmkit/ui/style.h
+++ b/src/rmkit/ui/style.h
@@ -8,13 +8,15 @@ namespace ui {
 
 struct Style {
     enum JUSTIFY { LEFT, CENTER, RIGHT };
+    enum VALIGN { TOP, MIDDLE, BOTTOM };
 
     // When adding a new style, make sure to also add builders in Stylesheet
     // and Stylesheet::Inherited.
     short font_size = DEFAULT.font_size;
     bool underline = DEFAULT.underline;
     JUSTIFY justify = DEFAULT.justify;
-    // TODO: valign, border, background, padding
+    VALIGN valign = DEFAULT.valign;
+    // TODO: border, background, padding
 
     static Style DEFAULT;
 };
@@ -89,10 +91,20 @@ public:
     Stylesheet & justify_center() { return justify(Style::JUSTIFY::CENTER); }
     Stylesheet & justify_right()  { return justify(Style::JUSTIFY::RIGHT); }
 
+    Stylesheet & valign(Style::VALIGN val) { return set(&Style::valign, val); }
+    Stylesheet & valign(const Style & src) { return copy(&Style::valign, src); }
+    Stylesheet & valign_top()    { return valign(Style::VALIGN::TOP); }
+    Stylesheet & valign_middle() { return valign(Style::VALIGN::MIDDLE); }
+    Stylesheet & valign_bottom() { return valign(Style::VALIGN::BOTTOM); }
+
     // Shortcuts
     Stylesheet & text_style(const Style & src)
     {
         return font_size(src).justify(src).underline(src);
+    }
+    Stylesheet & alignment(const Style & src)
+    {
+        return justify(src).valign(src);
     }
 };
 
@@ -118,13 +130,16 @@ public:
     Inherited & font_size() { sheet.font_size(src); return *this; }
     Inherited & underline() { sheet.underline(src); return *this; }
     Inherited & justify() { sheet.justify(src); return *this; }
+    Inherited & valign() { sheet.justify(src); return *this; }
     Inherited & text_style() { sheet.text_style(src); return *this; }
+    Inherited & alignment() { sheet.alignment(src); return *this; }
 };
 
 Style Style::DEFAULT = Stylesheet()
     .font_size(24)
     .underline(false)
     .justify_center()
+    .valign_top()
     .build();
 
 }

--- a/src/rmkit/ui/text.cpy
+++ b/src/rmkit/ui/text.cpy
@@ -36,22 +36,31 @@ namespace ui:
       memset(image.buffer, WHITE, sizeof(uint32_t) * image.w * image.h)
 
       leftover_x := self.w - image.w
-      padding_x := 0
+      draw_x := self.x
+      draw_y := self.y
 
       switch self.style.justify:
         case Style::JUSTIFY::CENTER:
           if leftover_x > 0:
-            padding_x = leftover_x / 2
+            draw_x += leftover_x / 2
           break
         case Style::JUSTIFY::RIGHT:
           if leftover_x > 0:
-            padding_x = leftover_x
+            draw_x += leftover_x
           break
 
-      fb->draw_text(self.text, self.x + padding_x, self.y, image, font_size)
+      switch self.style.valign:
+        case Style::VALIGN::MIDDLE:
+          draw_y += (self.h - font_size) / 2
+          break
+        case Style::VALIGN::BOTTOM:
+          draw_y += self.h - font_size
+          break
+
+      fb->draw_text(self.text, draw_x, draw_y, image, font_size)
       if self.style.underline:
-        fb->draw_line(self.x+padding_x, self.y+font_size, self.x+padding_x+image.w-font_size,
-                      self.y+font_size, 1, BLACK)
+        fb->draw_line(draw_x, draw_y+font_size, draw_x+image.w-font_size,
+                      draw_y+font_size, 1, BLACK)
 
       free(image.buffer)
 

--- a/src/rmkit/ui/widget.cpy
+++ b/src/rmkit/ui/widget.cpy
@@ -95,6 +95,20 @@ namespace ui:
     virtual void render():
       pass
 
+    // function: render_border
+    // redraws the widget border (happens after render())
+    virtual void render_border():
+      size := 1
+      if self.style.border_top:
+        self.fb->draw_rect(self.x, self.y, self.w, size, BLACK)
+      if self.style.border_bottom:
+        self.fb->draw_rect(self.x, self.y + self.h - size, self.w, size, BLACK)
+      if self.style.border_left:
+        self.fb->draw_rect(self.x, self.y, size, self.h, BLACK)
+      if self.style.border_right:
+        self.fb->draw_rect(self.x + self.w - size, self.y, size, self.h, BLACK)
+
+
     virtual void undraw():
       self.fb->draw_rect(self.x, self.y, self.w, self.h, WHITE, true)
 


### PR DESCRIPTION
Broken up in to separate commits; happy to make separate PRs if one of these is ok but the other needs more discussion.

Valign should be pretty straightforward, although I only implemented it for Text (and by extension, Button). The only odd part is setting y_padding to 0 instead of the default 10 when using a valign other than TOP.

Border might be a little more controversial. I intended to allow any widget to have a border, and the easiest way I could think of to do that was by drawing the border after `render()`, by having `Scene::redraw()` call `render_border()`. IDK if this is getting too complicated, but I was also thinking about adding `background` (color or transparent) as a style, and at that point it might be handy to move the full "render" cycle into Widget instead of Scene, e.g.:

```cpp
class Widget {
  // Instead of implementing render(), most classes would implement this
  virtual void render_content() {
  }

  // This is the "full" render function, usually not overridden 
  virtual void render() {
    before_render();
    if (! widget->visible)
      return;
    render_background();
    render_content();
    for (auto w : children)
      w->render();
    render_border();
  }
};
```