### PR TITLE
[ui] remove justify from text_style

### DIFF
--- a/src/rmkit/ui/style.h
+++ b/src/rmkit/ui/style.h
@@ -117,7 +117,7 @@ public:
     // Shortcuts
     Stylesheet & text_style(const Style & src)
     {
-        return font_size(src).justify(src).underline(src);
+        return font_size(src).underline(src);
     }
     Stylesheet & alignment(const Style & src)
     {


### PR DESCRIPTION
Now that we have valign, I think `justify` belongs in the `alignment` shortcut, not in the `text_style` shortcut. Maybe in the future `text_style` includes things like bold/italic/font_face if we end up wanting those.