### PR TITLE
[rmkit] Increase precision of color::to_float

### DIFF
--- a/src/rmkit/color.h
+++ b/src/rmkit/color.h
@@ -41,9 +41,9 @@ constexpr remarkable_color from_float(float n)
 constexpr float to_float(remarkable_color c)
 {
     // 0.21 R + 0.72 G + 0.07 B
-    return ((c >> 11) & 30) * (0.21 / 30)  // red
-         + ((c >> 5)  & 60) * (0.72 / 60)  // green
-         + (c         & 30) * (0.07 / 30); // blue
+    return ((c >> 11) & 31) * (0.21 / 31)  // red
+         + ((c >> 5)  & 63) * (0.72 / 63)  // green
+         + (c         & 31) * (0.07 / 31); // blue
 }
 
 // 16-gray palette (BLACK, WHITE, and 14 shades of gray)


### PR DESCRIPTION
I was playing around with your code at the end of #67 and it occurred to me that I was accidentally truncating a few bits off of each channel in the conversion to float. I had made an assumption in an earlier iteration of this code that using 30/60/30 for white (instead of 31/63/31) was the way to go, based on https://www.waveshare.com/w/upload/c/c4/E-paper-mode-declaration.pdf, but that turned out to be incorrect.

Just this small change gets us to 64 shades pretty easily. I can still see a tiny bit of banding on the GC16 gradient with dithering applied, but it's barely noticeable.