### PR TITLE
[fb] optimize dithering for WHITE and BLACK

### DIFF
--- a/src/rmkit/fb/dither.h
+++ b/src/rmkit/fb/dither.h
@@ -28,21 +28,25 @@ static const float BLUE_NOISE_MATRIX_16[32][32] = {{ 0.005338541666666667,-0.019
 
 inline remarkable_color BAYER_2(int x, int y, remarkable_color c)
 {
+    if (c == WHITE || c == BLACK) return c;
     return color::quantize<2>(color::to_float(c) + BAYER_MATRIX_2[x%32][y%32]);
 }
 
 inline remarkable_color BAYER_16(int x, int y, remarkable_color c)
 {
+    if (c == WHITE || c == BLACK) return c;
     return color::quantize<16>(color::to_float(c) + BAYER_MATRIX_16[x%32][y%32]);
 }
 
 inline remarkable_color BLUE_NOISE_2(int x, int y, remarkable_color c)
 {
+    if (c == WHITE || c == BLACK) return c;
     return color::quantize<2>(color::to_float(c) + BLUE_NOISE_MATRIX_2[x%32][y%32]);
 }
 
 inline remarkable_color BLUE_NOISE_16(int x, int y, remarkable_color c)
 {
+    if (c == WHITE || c == BLACK) return c;
     return color::quantize<16>(color::to_float(c) + BLUE_NOISE_MATRIX_16[x%32][y%32]);
 }
 


### PR DESCRIPTION
I've noticed that some of the remarkable_puzzle animations are super slow, so I've been doing some profiling. `draw_rect` and whichever dithering function I use together take up about 90% of the time according to gprof, so I'm focusing on those :)

One pretty simple optimization is skipping dithering for WHITE and BLACK colors -- the dithering matrices are normalized so that they add or subtract less than 50% of the difference between two colors (so, e.g. in 2-color dithering 0.0 is shifted to between -0.49 and 0.49, which rounds back to 0.0 in all cases).

This change gives me between a 2x and 5x speedup in dithering, depending on how much gray is being drawn:

<details>
<summary>A sample of lightup, which uses a lot of gray:</summary>

```
# before
  %   cumulative   self              self     total           
 time   seconds   seconds    calls  ms/call  ms/call  name    
 45.86      1.22     1.22 24576951     0.00     0.00  framebuffer::DITHER::BAYER_2(int, int, unsigned short)
 39.47      2.27     1.05  1253836     0.00     0.00  framebuffer::FB::draw_rect(int, int, int, int, int, int, float)

# after
  %   cumulative   self              self     total           
 time   seconds   seconds    calls  ms/call  ms/call  name    
 54.08      1.06     1.06  1259815     0.00     0.00  framebuffer::FB::draw_rect(int, int, int, int, int, int, float)
 31.12      1.67     0.61 27939892     0.00     0.00  framebuffer::DITHER::BAYER_2(int, int, unsigned short)
```
</details>

<details>
<summary>A sample of untangle, which is almost all black and white:</summary>

```
# before
  %   cumulative   self               self     total           
 time   seconds   seconds     calls  ms/call  ms/call  name    
 61.84      7.34     7.34 165550334     0.00     0.00  framebuffer::DITHER::BAYER_2(int, int, unsigned short)
 35.89     11.60     4.26   2498395     0.00     0.00  framebuffer::FB::draw_rect(int, int, int, int, int, int, float)

  %   cumulative   self               self     total           
 time   seconds   seconds     calls  ms/call  ms/call  name    
 78.94      5.51     5.51   3671557     0.00     0.00  framebuffer::FB::draw_rect(int, int, int, int, int, int, float)
 16.48      6.66     1.15 240161310     0.00     0.00  framebuffer::DITHER::BAYER_2(int, int, unsigned short)
```
</details>

I'd also be happy to add these as separate dithering modes (e.g. `BAYER_BW_2` or something), in case we want to let users opt in to this behavior. If you were rendering a grayscale bitmap, for instance, this is probably unhelpful, and just adds 2 extra comparisons per pixel.