### PR TITLE
Line height style

### DIFF
--- a/src/rmkit/defines.h
+++ b/src/rmkit/defines.h
@@ -102,6 +102,16 @@ std::vector<std::string> split (const std::string &s, char delim) {
   return result;
 }
 
+std::vector<std::string> split_lines(const std::string &s) {
+  std::vector<std::string> result;
+  std::stringstream ss (s);
+  std::string item;
+  while (getline (ss, item)) {
+    result.push_back (item);
+  }
+  return result;
+}
+
 bool ends_with (std::string const &fullString, std::string const &ending) {
     if (fullString.length() >= ending.length()) {
         return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));

--- a/src/rmkit/fb/stb_text.cpy
+++ b/src/rmkit/fb/stb_text.cpy
@@ -42,6 +42,13 @@ namespace stbtext:
         uint32_t val = bitmap.buffer[q * bitmap.w + p];
         image.buffer[j*image.w+i] = val == 0 ? WHITE: BLACK;
 
+  int get_line_height(int font_size=FONT_SIZE):
+    setup_font()
+    float scale = stbtt_ScaleForPixelHeight(&font, font_size)
+    int ascent, descent, lineGap
+    stbtt_GetFontVMetrics(&font, &ascent, &descent, &lineGap)
+    return scale * (ascent - descent + lineGap) + 0.5;
+
   image_data get_text_size(std::string &text, int font_size=FONT_SIZE):
     int i,j,ascent,baseline;
     int ch=0;

--- a/src/rmkit/ui/style.h
+++ b/src/rmkit/ui/style.h
@@ -15,6 +15,7 @@ struct Style {
     // When adding a new style, make sure to also add builders in Stylesheet
     // and InheritedStylesheet.
     short font_size = DEFAULT.font_size;
+    float line_height = DEFAULT.line_height;
     bool underline = DEFAULT.underline;
     JUSTIFY justify = DEFAULT.justify;
     VALIGN valign = DEFAULT.valign;
@@ -89,6 +90,9 @@ public:
     Stylesheet font_size(short val) { return set(&Style::font_size, val); }
     Stylesheet font_size(const Style & src) { return copy(&Style::font_size, src); }
 
+    Stylesheet line_height(float val) { return set(&Style::line_height, val); }
+    Stylesheet line_height(const Style & src) { return copy(&Style::line_height, src); }
+
     Stylesheet underline(bool val=true) { return set(&Style::underline, val); }
     Stylesheet underline(const Style & src) { return copy(&Style::underline, src); }
 
@@ -120,7 +124,7 @@ public:
     // Shortcuts
     Stylesheet text_style(const Style & src)
     {
-        return font_size(src).underline(src);
+        return font_size(src).line_height(src).underline(src);
     }
     Stylesheet alignment(const Style & src)
     {
@@ -155,6 +159,7 @@ public:
 
     // Builders
     InheritedStylesheet font_size() { return _inherit(&Stylesheet::font_size); }
+    InheritedStylesheet line_height() { return _inherit(&Stylesheet::line_height); }
     InheritedStylesheet underline() { return _inherit(&Stylesheet::underline); }
     InheritedStylesheet justify() { return _inherit(&Stylesheet::justify); }
     InheritedStylesheet valign() { return _inherit(&Stylesheet::valign); }
@@ -174,6 +179,7 @@ InheritedStylesheet Style::inherit() const
 
 Style Style::DEFAULT = Stylesheet()
     .font_size(24)
+    .line_height(1.2)
     .underline(false)
     .justify_center()
     .valign_top()

--- a/src/rmkit/ui/text.cpy
+++ b/src/rmkit/ui/text.cpy
@@ -89,7 +89,7 @@ namespace ui:
     void render():
       cur_x := 0
       cur_y := 0
-      lines := split(self.text, '\n')
+      lines := split_lines(self.text)
       font_size := self.style.font_size
       line_height := stbtext::get_line_height(font_size) * self.style.line_height
       for auto line: lines:
@@ -116,7 +116,7 @@ namespace ui:
       cur_y := 0
       ret_w := 0
       ret_h := 0
-      lines := split(self.text, '\n')
+      lines := split_lines(self.text)
       font_size := self.style.font_size
       line_height := stbtext::get_line_height(font_size) * self.style.line_height
       for auto line: lines:

--- a/src/rmkit/ui/text.cpy
+++ b/src/rmkit/ui/text.cpy
@@ -91,26 +91,25 @@ namespace ui:
       cur_y := 0
       lines := split(self.text, '\n')
       font_size := self.style.font_size
+      line_height := stbtext::get_line_height(font_size) * self.style.line_height
       for auto line: lines:
         cur_x = 0
         tokens := split(line, ' ')
-        int max_h = 0
         for auto w: tokens:
           w += " "
           image := stbtext::get_text_size(w, font_size)
           image.buffer = (uint32_t*) malloc(sizeof(uint32_t) * image.w * image.h)
-          max_h = max(image.h, max_h)
           memset(image.buffer, WHITE, sizeof(uint32_t) * image.w * image.h)
           if cur_x + image.w + 10 >= self.w:
             cur_x = 0
-            cur_y += max_h
+            cur_y += line_height
           self.fb->draw_text(w, self.x + cur_x, self.y + cur_y, image, font_size)
           if self.style.underline:
             self.fb->draw_line(self.x+cur_x, self.y+cur_y+font_size, self.x+cur_x+image.w,
                                self.y + cur_y+font_size, 1, BLACK)
           free(image.buffer)
           cur_x += image.w
-        cur_y += max_h
+        cur_y += line_height
 
     tuple<int, int> get_render_size():
       cur_x := 0
@@ -118,19 +117,19 @@ namespace ui:
       ret_w := 0
       ret_h := 0
       lines := split(self.text, '\n')
+      font_size := self.style.font_size
+      line_height := stbtext::get_line_height(font_size) * self.style.line_height
       for auto line: lines:
         cur_x = 0
         tokens := split(line, ' ')
-        int max_h = 0
         for auto w: tokens:
           w += " "
-          image := stbtext::get_text_size(w, self.style.font_size)
-          max_h = max(image.h, max_h)
+          image := stbtext::get_text_size(w, font_size)
           if cur_x + image.w + 10 >= self.w:
             cur_x = 0
-            cur_y += max_h
+            cur_y += line_height
           cur_x += image.w
-        cur_y += max_h
+        cur_y += line_height
 
         ret_h = max(ret_h, cur_y)
         ret_w = max(ret_w, cur_y)


### PR DESCRIPTION
I'm working on puzzle help screens, and noticed that MultiText doesn't support multiple consecutive newlines (as a paragraph break for instance). This needed a 2-part approach: (1) a new split fn that doesn't skip whitespace, (2) using a fixed line_height for shifting the y coordinate between lines, since blank lines don't have any characters to measure. The new line_height style lets you scale the computed line height. I went with 1.2 as a default, since that's what css uses. Even with that default though I noticed that paragraphs are much shorter than they were previously, so I'm happy to make the default higher for backwards compatibility.