### PR TITLE
[rmkit][input] copy old mt slots from previous event

### DIFF
--- a/src/remux/launcher.cpy
+++ b/src/remux/launcher.cpy
@@ -603,6 +603,10 @@ class App: public IApp:
     fd := ui::MainLoop::in.touch.fd
     bytes := write(fd, touch_flood, 512 * 8 * 4 * sizeof(input_event))
 
+    for i := 0; i < input::TouchEvent::MAX_SLOTS; i++:
+      ui::MainLoop::in.touch.prev_ev.slots[i].left = 0
+      ui::MainLoop::in.touch.event.slots[i].left = 0
+
   // TODO: figure out the right events here to properly flood this device
   void flood_button_queue():
     fd := ui::MainLoop::in.button.fd

--- a/src/rmkit/init.cpy
+++ b/src/rmkit/init.cpy
@@ -48,8 +48,6 @@ static void _rmkit_init():
 
   fb := framebuffer::get()
   ui::Widget::fb = fb.get()
-  w, h = fb->get_display_size()
-  input::MouseEvent::set_screen_size(w, h)
 
   for auto s : { SIGINT, SIGTERM, SIGABRT, SIGSEGV}:
     signal(s, _rmkit_exit)

--- a/src/rmkit/input/events.cpy
+++ b/src/rmkit/input/events.cpy
@@ -146,25 +146,6 @@ namespace input:
 
           break
 
-    def merge(TouchEvent &prev):
-      if self.x == -1:
-        self.x = prev.x
-      if self.y == -1:
-        self.y = prev.y
-      if self.left == -1:
-        self.left = prev.left
-
-      self.fingers = 0
-      // merge slots from previous mt into this one
-      for i := 0; i < MAX_SLOTS; i++:
-        if prev.slots[i].left == 1:
-          if slots[i].x == -1:
-            slots[i].x = prev.slots[i].x
-          if slots[i].y == -1:
-            slots[i].y = prev.slots[i].y
-          if slots[i].left == -1:
-            slots[i].left = prev.slots[i].left
-
     def marshal():
       SynMotionEvent syn_ev;
 
@@ -202,62 +183,6 @@ namespace input:
 
 
   int TouchEvent::MAX_SLOTS = 10
-
-  class MouseEvent: public Event:
-    public:
-    MouseEvent() {}
-    int x = 0, y = 0
-    signed char dx = 0, dy = 0
-    int left = 0 , right = 0 , middle = 0
-    static int width, height
-    static int tilt_x
-    static int tilt_y
-    static int pressure
-
-
-    static void set_screen_size(int w, h):
-      width = w
-      height = h
-
-    def update(input_event data):
-      self.print_event(data)
-
-    def merge(MouseEvent &prev):
-      self.x = prev.x + self.dx
-      self.y = prev.y + self.dy
-
-      if self.y < 0:
-        self.y = 0
-      if self.x < 0:
-        self.x = 0
-
-      if self.y >= self.height - 1:
-        self.y = (int) self.height - 5
-
-      if self.x >= self.width - 1:
-        self.x = (int) self.width - 5
-
-    def marshal():
-      o_x := self.x
-      o_y := self.height - self.y
-
-      if o_y >= self.height - 1:
-        o_y = self.height - 5
-
-      SynMotionEvent syn_ev;
-      syn_ev.x = o_x
-      syn_ev.y = o_y
-      syn_ev.left = self.left
-      syn_ev.right = self.right
-      syn_ev.pressure = MouseEvent::pressure
-      syn_ev.tilt_x = MouseEvent::tilt_x
-      syn_ev.tilt_y = MouseEvent::tilt_y
-
-      syn_ev.set_original(new MouseEvent(*self))
-      return syn_ev
-
-  int MouseEvent::width = 0
-  int MouseEvent::height = 0
 
   class WacomEvent: public Event:
     public:
@@ -330,7 +255,3 @@ namespace input:
           self.handle_key(data)
         case 3:
           self.handle_abs(data)
-
-  int MouseEvent::pressure = 2000
-  int MouseEvent::tilt_x = 0
-  int MouseEvent::tilt_y = 0

--- a/src/rmkit/input/events.cpy
+++ b/src/rmkit/input/events.cpy
@@ -92,7 +92,6 @@ namespace input:
     public:
     int x=-1, y=-1
     int slot = 0, left = -1
-    int fingers = 0
     bool lifted=false
     static int MAX_SLOTS
     struct Point:
@@ -153,23 +152,21 @@ namespace input:
           self.handle_abs(data)
 
     def count_fingers():
-      self.fingers = 0
+      fingers := 0
       for i := 0; i < MAX_SLOTS; i++:
         if slots[i].left == 1:
-          self.fingers++
+          fingers++
+
+      return fingers
 
     def is_multitouch():
-      self.count_fingers()
+      fingers := self.count_fingers()
 
-      if self.fingers > 1:
+      if fingers > 1:
         return true
 
-      if self.fingers == 0:
+      if fingers == 0:
         return false
-
-    void finalize():
-      self.count_fingers()
-
 
   int TouchEvent::MAX_SLOTS = 10
 

--- a/src/rmkit/input/events.cpy
+++ b/src/rmkit/input/events.cpy
@@ -81,9 +81,6 @@ namespace input:
 
       self.print_event(data)
 
-    def merge(ButtonEvent &prev):
-      pass
-
     def marshal():
       SynKeyEvent key_ev
       key_ev.key = self.key
@@ -190,19 +187,6 @@ namespace input:
     int tilt_x = 0xFFFF, tilt_y = 0xFFFF
     int btn_touch = -1
     int eraser = -1
-
-
-    def merge(WacomEvent &prev):
-      if self.btn_touch == -1:
-        self.btn_touch = prev.btn_touch
-      if self.eraser == -1:
-        self.eraser = prev.eraser
-      if self.pressure == -1 || self.pressure == 0:
-        self.pressure = prev.pressure
-      if self.tilt_x == 0xFFFF:
-        self.tilt_x = prev.tilt_x
-      if self.tilt_y == 0xFFFF:
-        self.tilt_y = prev.tilt_y
 
     def marshal():
       SynMotionEvent syn_ev;

--- a/src/rmkit/input/events.cpy
+++ b/src/rmkit/input/events.cpy
@@ -103,14 +103,6 @@ namespace input:
     TouchEvent():
       slots.resize(MAX_SLOTS)
 
-    TouchEvent(const TouchEvent &t):
-      self.slot = t.slot
-      self.slots = t.slots
-      self.x = t.x
-      self.y = t.y
-      self.left = t.left
-      self.lifted = t.lifted
-
     void initialize():
       self.lifted = false
 

--- a/src/rmkit/input/events.cpy
+++ b/src/rmkit/input/events.cpy
@@ -78,7 +78,10 @@ namespace input:
 
       self.print_event(data)
 
-    def marshal(ButtonEvent &prev):
+    def merge(ButtonEvent &prev):
+      pass
+
+    def marshal():
       SynKeyEvent key_ev
       key_ev.key = self.key
       key_ev.is_pressed = self.is_pressed
@@ -133,9 +136,7 @@ namespace input:
             slots[slot].left = self.left = data.value > -1
           break
 
-    def marshal(TouchEvent &prev):
-      SynMotionEvent syn_ev;
-
+    def merge(TouchEvent &prev):
       if self.x == -1:
         self.x = prev.x
       if self.y == -1:
@@ -162,6 +163,9 @@ namespace input:
 
       if self.fingers == 0:
         self.is_multitouch = false
+
+    def marshal():
+      SynMotionEvent syn_ev;
 
       syn_ev.left = self.left
       syn_ev.x = self.x
@@ -198,7 +202,7 @@ namespace input:
     def update(input_event data):
       self.print_event(data)
 
-    def marshal(MouseEvent &prev):
+    def merge(MouseEvent &prev):
       self.x = prev.x + self.dx
       self.y = prev.y + self.dy
 
@@ -213,6 +217,7 @@ namespace input:
       if self.x >= self.width - 1:
         self.x = (int) self.width - 5
 
+    def marshal():
       o_x := self.x
       o_y := self.height - self.y
 
@@ -241,11 +246,8 @@ namespace input:
     int btn_touch = -1
     int eraser = -1
 
-    def marshal(WacomEvent &prev):
-      SynMotionEvent syn_ev;
-      syn_ev.x = self.x
-      syn_ev.y = self.y
 
+    def merge(WacomEvent &prev):
       if self.btn_touch == -1:
         self.btn_touch = prev.btn_touch
       if self.eraser == -1:
@@ -256,6 +258,11 @@ namespace input:
         self.tilt_x = prev.tilt_x
       if self.tilt_y == 0xFFFF:
         self.tilt_y = prev.tilt_y
+
+    def marshal():
+      SynMotionEvent syn_ev;
+      syn_ev.x = self.x
+      syn_ev.y = self.y
 
       syn_ev.pressure = self.pressure
       syn_ev.tilt_x = self.tilt_x

--- a/src/rmkit/input/gestures.cpy
+++ b/src/rmkit/input/gestures.cpy
@@ -198,6 +198,9 @@ namespace input:
       handle_event(ev)
 
     void handle_event(input::TouchEvent &ev):
+      if abs(ev.y - start.y) > 10 or abs(ev.x - start.x) > 10:
+        self.valid = false
+
       if ev.slot >= self.fingers:
         self.valid = false
       else:
@@ -208,6 +211,9 @@ namespace input:
 
 
     bool filter(input::TouchEvent &ev):
+      if ev.y == -1 or ev.x == -1:
+        return false
+
       if ev.slot + 1 < self.fingers:
         return false
 

--- a/src/rmkit/input/gestures.cpy
+++ b/src/rmkit/input/gestures.cpy
@@ -103,7 +103,7 @@ namespace input:
             debug "FILTERED JUMP X", ev.x, ev.y, ev.slot
           return false
 
-      if ev.slot + 1 != self.fingers:
+      if ev.fingers != self.fingers:
         if DEBUG_GESTURE_FILTERS:
           debug "FILTERED FINGERS", ev.x, ev.y, ev.slot
         return false
@@ -201,7 +201,7 @@ namespace input:
       if abs(ev.y - start.y) > 10 or abs(ev.x - start.x) > 10:
         self.valid = false
 
-      if ev.slot >= self.fingers:
+      if ev.fingers > self.fingers:
         self.valid = false
       else:
         if duration > 0:
@@ -214,7 +214,7 @@ namespace input:
       if ev.y == -1 or ev.x == -1:
         return false
 
-      if ev.slot + 1 < self.fingers:
+      if ev.fingers < self.fingers:
         return false
 
       return true

--- a/src/rmkit/input/gestures.cpy
+++ b/src/rmkit/input/gestures.cpy
@@ -103,7 +103,7 @@ namespace input:
             debug "FILTERED JUMP X", ev.x, ev.y, ev.slot
           return false
 
-      if ev.fingers != self.fingers:
+      if ev.count_fingers() != self.fingers:
         if DEBUG_GESTURE_FILTERS:
           debug "FILTERED FINGERS", ev.x, ev.y, ev.slot
         return false
@@ -201,7 +201,7 @@ namespace input:
       if abs(ev.y - start.y) > 10 or abs(ev.x - start.x) > 10:
         self.valid = false
 
-      if ev.fingers > self.fingers:
+      if ev.count_fingers() > self.fingers:
         self.valid = false
       else:
         if duration > 0:
@@ -214,7 +214,7 @@ namespace input:
       if ev.y == -1 or ev.x == -1:
         return false
 
-      if ev.fingers < self.fingers:
+      if ev.count_fingers() < self.fingers:
         return false
 
       return true

--- a/src/rmkit/input/input.cpy
+++ b/src/rmkit/input/input.cpy
@@ -34,7 +34,8 @@ namespace input:
     clear():
       self.events.clear()
 
-    def marshal(T ev):
+    // marshal can update the event
+    def marshal(T &ev):
       EV syn_ev = ev.marshal(prev_ev)
       prev_ev = ev
       return syn_ev
@@ -216,16 +217,16 @@ namespace input:
         if FD_ISSET(input::ipc_fd[0], &rdfs_cp):
           self.handle_ipc()
 
-      for auto ev : self.wacom.events:
+      for auto &ev : self.wacom.events:
         self.all_motion_events.push_back(self.wacom.marshal(ev))
 
-      for auto ev : self.mouse.events:
+      for auto &ev : self.mouse.events:
         self.all_motion_events.push_back(self.mouse.marshal(ev))
 
-      for auto ev : self.touch.events:
+      for auto &ev : self.touch.events:
         self.all_motion_events.push_back(self.touch.marshal(ev))
 
-      for auto ev : self.button.events:
+      for auto &ev : self.button.events:
         self.all_key_events.push_back(self.button.marshal(ev))
 
       #ifdef DEBUG_INPUT_EVENT

--- a/src/rmkit/input/input.cpy
+++ b/src/rmkit/input/input.cpy
@@ -59,7 +59,7 @@ namespace input:
           fprintf(stderr, "\n")
           #endif
           prev_ev = event
-          event = prev_ev
+          event.initialize()
         else:
           event.update(ev_data[i])
 

--- a/src/rmkit/input/input.cpy
+++ b/src/rmkit/input/input.cpy
@@ -36,8 +36,8 @@ namespace input:
 
     // marshal can update the event
     def marshal(T &ev):
-      ev.merge(prev_ev)
-      prev_ev = ev
+      // ev.merge(prev_ev)
+      // prev_ev = ev
 
       return ev.marshal()
 
@@ -50,8 +50,9 @@ namespace input:
       // in DEV mode we allow event coalescing between calls to read() for
       // resim normally evdev will do one full event per read() call instead of
       // splitting across multiple read() calls
-      T event
+      T event = prev_ev
       #endif
+      event.initialize()
 
       for int i = 0; i < bytes / sizeof(struct input_event); i++:
 //        debug fd, "READ EVENT", ev_data[i].type, ev_data[i].code, ev_data[i].value
@@ -61,7 +62,8 @@ namespace input:
           #ifdef DEBUG_INPUT_EVENT
           fprintf(stderr, "\n")
           #endif
-          event = {} // clear the event?
+          prev_ev = event
+          event = prev_ev
         else:
           event.update(ev_data[i])
 

--- a/src/rmkit/input/input.cpy
+++ b/src/rmkit/input/input.cpy
@@ -34,11 +34,7 @@ namespace input:
     clear():
       self.events.clear()
 
-    // marshal can update the event
     def marshal(T &ev):
-      // ev.merge(prev_ev)
-      // prev_ev = ev
-
       return ev.marshal()
 
     void handle_event_fd():

--- a/src/rmkit/input/input.cpy
+++ b/src/rmkit/input/input.cpy
@@ -36,9 +36,10 @@ namespace input:
 
     // marshal can update the event
     def marshal(T &ev):
-      EV syn_ev = ev.marshal(prev_ev)
+      ev.merge(prev_ev)
       prev_ev = ev
-      return syn_ev
+
+      return ev.marshal()
 
     void handle_event_fd():
       int bytes = read(fd, ev_data, sizeof(input_event) * 64);

--- a/src/rmkit/ui/main_loop.cpy
+++ b/src/rmkit/ui/main_loop.cpy
@@ -136,17 +136,12 @@ namespace ui:
 
       for auto ev: ui::MainLoop::in.touch.events:
         for auto g : gestures:
-          lifted := false
-          for int s = 0; s < input::TouchEvent::MAX_SLOTS; s++:
-            if ev.slots[s].left == 0:
-              lifted = true
-              break
-
-          if lifted:
+          if ev.lifted:
             if g->valid:
               g->finalize()
             g->reset()
           else:
+            ev.count_fingers()
             if g->filter(ev):
               if !g->initialized:
                 if DEBUG_GESTURES:

--- a/src/rmkit/ui/main_loop.cpy
+++ b/src/rmkit/ui/main_loop.cpy
@@ -137,7 +137,7 @@ namespace ui:
       for auto ev: ui::MainLoop::in.touch.events:
         for auto g : gestures:
           lifted := false
-          for int s = 0; s <= ev.slot; s++:
+          for int s = 0; s < input::TouchEvent::MAX_SLOTS; s++:
             if ev.slots[s].left == 0:
               lifted = true
               break


### PR DESCRIPTION
* remove wonky backwards event coalescing, instead start with prev_ev for all events
* remove MouseEvent, its not applicable since we started using resim
* set `lifted` on TouchEvent when a finger is lifted (TRACKING_ID set to -1)
* add count_fingers() to TouchEvent and use TouchEvent.fingers in gestures.cpy for figuring out how many fingers pressed