### PR TITLE
[rmkit] Add simple Widget gestures

### DIFF
--- a/src/input_demo/main.cpy
+++ b/src/input_demo/main.cpy
@@ -2,6 +2,66 @@
 #include "../build/rmkit.h"
 using namespace std
 
+class GestureWidget : public ui::Widget:
+  public:
+  int square_x, square_y
+  int size = 60
+  int drag_x, drag_y
+  remarkable_color default_fill = BLACK
+  remarkable_color fill = BLACK
+  remarkable_color outline = BLACK
+  remarkable_color widget_outline = BLACK
+
+  GestureWidget(int x, y, w, h) : ui::Widget(x, y, w, h):
+    square_x = w / 2
+    square_y = h / 2
+    // drag events
+    gesture.drag_start += PLS_LAMBDA(auto & ev) {
+      debug "DRAG START"
+      fill = GRAY
+      drag_x = ev.x - square_x
+      drag_y = ev.y - square_y
+      dirty = 1
+    }
+    gesture.drag_end += PLS_LAMBDA(auto & ev) {
+      debug "DRAG END"
+      fill = default_fill
+      dirty = 1
+    }
+    gesture.dragging += PLS_LAMBDA(auto & ev) {
+      debug "DRAGGING", ev.x, ev.y
+      square_x = max(x+(size/2),min(x+w-(size/2), ev.x - drag_x))
+      square_y = max(y+(size/2),min(y+h-(size/2), ev.y - drag_y))
+      dirty = 1
+    }
+    // click events
+    gesture.long_press += PLS_LAMBDA(auto & ev) {
+      debug "LONG PRESS", ev.x, ev.y
+      widget_outline = (widget_outline == BLACK) ? GRAY : BLACK
+      dirty = 1
+    }
+    gesture.single_click += PLS_LAMBDA(auto & ev) {
+      debug "SINGLE CLICK", ev.x, ev.y
+      default_fill = fill = (fill == BLACK) ? WHITE : BLACK
+      dirty = 1
+    }
+    gesture.double_click += PLS_LAMBDA(auto & ev) {
+      debug "DOUBLE CLICK", ev.x, ev.y
+      outline = (outline == BLACK) ? GRAY : BLACK
+      dirty = 1
+    }
+
+  void render():
+    // background
+    fb->draw_rect(x+10, y+10, w-20, h-20, WHITE, true)
+    for i 0 10:
+      fb->draw_rect(x+i, y+i, w-2*i, h-2*i, widget_outline, false)
+    // drag rect
+    cx := x + square_x
+    cy := y + square_y
+    fb->draw_rect(cx - (size/2),     cy - (size/2),     size,    size,    outline)
+    fb->draw_rect(cx - (size/2) + 5, cy - (size/2) + 5, size-10, size-10, fill)
+
 class App:
   public:
   ui::Scene demo_scene
@@ -67,6 +127,10 @@ class App:
       debug "SELECTED", idx, text_dropdown->options[idx]->name
     ;
     h_layout.pack_center(text_dropdown)
+
+    auto drag = new GestureWidget(0, 0, 800, 800)
+    v_layout.pack_center(drag)
+    h_layout.pack_center(drag)
 
   def handle_key_event(input::SynKeyEvent &key_ev):
     debug "KEY PRESSED", key_ev.key

--- a/src/input_demo/main.cpy
+++ b/src/input_demo/main.cpy
@@ -16,36 +16,36 @@ class GestureWidget : public ui::Widget:
     square_x = w / 2
     square_y = h / 2
     // drag events
-    gesture.drag_start += PLS_LAMBDA(auto & ev) {
+    gestures.drag_start += PLS_LAMBDA(auto & ev) {
       debug "DRAG START"
       fill = GRAY
       drag_x = ev.x - square_x
       drag_y = ev.y - square_y
       dirty = 1
     }
-    gesture.drag_end += PLS_LAMBDA(auto & ev) {
+    gestures.drag_end += PLS_LAMBDA(auto & ev) {
       debug "DRAG END"
       fill = default_fill
       dirty = 1
     }
-    gesture.dragging += PLS_LAMBDA(auto & ev) {
+    gestures.dragging += PLS_LAMBDA(auto & ev) {
       debug "DRAGGING", ev.x, ev.y
       square_x = max(x+(size/2),min(x+w-(size/2), ev.x - drag_x))
       square_y = max(y+(size/2),min(y+h-(size/2), ev.y - drag_y))
       dirty = 1
     }
     // click events
-    gesture.long_press += PLS_LAMBDA(auto & ev) {
+    gestures.long_press += PLS_LAMBDA(auto & ev) {
       debug "LONG PRESS", ev.x, ev.y
       widget_outline = (widget_outline == BLACK) ? GRAY : BLACK
       dirty = 1
     }
-    gesture.single_click += PLS_LAMBDA(auto & ev) {
+    gestures.single_click += PLS_LAMBDA(auto & ev) {
       debug "SINGLE CLICK", ev.x, ev.y
       default_fill = fill = (fill == BLACK) ? WHITE : BLACK
       dirty = 1
     }
-    gesture.double_click += PLS_LAMBDA(auto & ev) {
+    gestures.double_click += PLS_LAMBDA(auto & ev) {
       debug "DOUBLE CLICK", ev.x, ev.y
       outline = (outline == BLACK) ? GRAY : BLACK
       dirty = 1

--- a/src/rmkit/ui/events.cpy
+++ b/src/rmkit/ui/events.cpy
@@ -150,8 +150,7 @@ namespace ui:
     MOUSE_EVENTS * mouse;
 
     template<MOUSE_EVENT GESTURE_EVENTS::*MEM>
-    class event_delegate:
-      private:
+    struct event_delegate:
       GESTURE_EVENTS_DELEGATE * parent;
 
       MOUSE_EVENT & get():
@@ -160,7 +159,6 @@ namespace ui:
           parent->gestures->attach(parent->mouse)
         return (*parent->gestures).*MEM
 
-      public:
       void operator+=(std::function<void(input::SynMotionEvent &)> f):
         get() += f
 

--- a/src/rmkit/ui/events.cpy
+++ b/src/rmkit/ui/events.cpy
@@ -1,0 +1,185 @@
+#include <cmath>
+
+#include "../input/events.h"
+#include "../util/signals.h"
+#include "timer.h"
+
+namespace ui:
+  PLS_DEFINE_SIGNAL(MOUSE_EVENT, input::SynMotionEvent)
+  class MOUSE_EVENTS:
+    public:
+    MOUSE_EVENT enter
+    MOUSE_EVENT leave
+    MOUSE_EVENT down
+    MOUSE_EVENT up
+    MOUSE_EVENT click
+    MOUSE_EVENT hover
+    MOUSE_EVENT move
+  ;
+
+  PLS_DEFINE_SIGNAL(KEY_EVENT, input::SynKeyEvent)
+  class KEY_EVENTS:
+    public:
+    KEY_EVENT pressed
+  ;
+
+  class GESTURE_EVENTS:
+    public:
+    MOUSE_EVENT long_press
+    MOUSE_EVENT single_click
+    MOUSE_EVENT double_click
+    MOUSE_EVENT drag_start
+    MOUSE_EVENT dragging
+    MOUSE_EVENT drag_end
+
+    // The threshold area that determines if this is a touch-based gesture
+    // (e.g. long_press, double_click) or a motion-based gesture (e.g. drag).
+    int touch_slop_size = 50
+
+    // Once dragging, only submit events when the x or y delta > this step.
+    // This limits the number of dragging events.
+    int dragging_step_size = 25
+
+    // Length of time (in ms) between a down event and a long_press
+    long long_press_timeout = 500
+
+    // Maximum gap (in ms) between clicks for a gesture to be considered a
+    // double_click. If there are any double_click handlers registered, this
+    // delay must pass without another down event before single_click will be
+    // triggered (otherwise single_click is triggered immediately on up).
+    long double_click_timeout = 250
+
+    // State machine
+    void attach(MOUSE_EVENTS * mouse):
+      mouse->down += PLS_LAMBDA(auto &ev) {
+        switch state:
+          case IDLE:              return IDLE_down(ev)
+          case WAIT_DOUBLE_CLICK: return WAIT_DOUBLE_CLICK_down(ev)
+          default:                return reset()
+      }
+      mouse->up += PLS_LAMBDA(auto &ev) {
+        switch state:
+          case DOWN:        return DOWN_up(ev)
+          case DRAGGING:    return finish(drag_end, ev)
+          case SECOND_DOWN: return finish(double_click, ev)
+          default:          return reset()
+      }
+      mouse->move += PLS_LAMBDA(auto &ev) {
+        switch state:
+          case DOWN:        return DOWN_move(ev)
+          case DRAGGING:    return DRAGGING_move(ev)
+          default:          return
+      }
+      mouse->leave += PLS_LAMBDA(auto &ev) {
+        switch state:
+          case DRAGGING:    return finish(drag_end, ev)
+          default:          return reset()
+      }
+
+    protected:
+    input::SynMotionEvent prev_ev
+    TimerPtr long_press_timer
+    TimerPtr single_click_timer
+    enum STATE { IDLE, DOWN, DRAGGING, WAIT_DOUBLE_CLICK, SECOND_DOWN }
+    STATE state = IDLE
+
+    inline void IDLE_down(input::SynMotionEvent &ev):
+      reset()
+      state = DOWN
+      prev_ev = ev
+      if not long_press.empty():
+        long_press_timer = ui::set_timeout([=]() {
+          auto ev_copy = ev
+          finish(long_press, ev_copy)
+        }, long_press_timeout)
+
+    inline void DOWN_up(input::SynMotionEvent &ev):
+      cancel_long_press()
+      if double_click.empty():
+        finish(single_click, ev)
+      else:
+        state = WAIT_DOUBLE_CLICK
+        single_click_timer = ui::set_timeout([=]() {
+          auto ev_copy = ev
+          finish(single_click, ev_copy)
+        }, double_click_timeout)
+
+    inline void DOWN_move(input::SynMotionEvent &ev):
+      if outside_tolerance(ev, touch_slop_size):
+        state = DRAGGING
+        cancel_long_press()
+        drag_start(ev)
+
+    inline void WAIT_DOUBLE_CLICK_down(input::SynMotionEvent &ev):
+      state = SECOND_DOWN
+      cancel_single_click()
+      prev_ev = ev
+
+    inline void DRAGGING_move(input::SynMotionEvent &ev):
+      if outside_tolerance(ev, dragging_step_size):
+        dragging(ev)
+        prev_ev = ev
+
+    // helpers
+    void reset():
+      cancel_long_press()
+      cancel_single_click()
+      state = IDLE
+
+    inline void finish(MOUSE_EVENT & handler, input::SynMotionEvent & ev):
+      handler(ev)
+      reset()
+
+    void cancel_long_press()
+      if long_press_timer:
+        ui::cancel_timer(long_press_timer)
+        long_press_timer = nullptr
+
+    void cancel_single_click()
+      if single_click_timer:
+        ui::cancel_timer(single_click_timer)
+        single_click_timer = nullptr
+
+    bool outside_tolerance(const input::SynMotionEvent & ev, int tolerance):
+     return std::abs(ev.x - prev_ev.x) > tolerance || std::abs(ev.y - prev_ev.y) > tolerance
+  ;
+
+  class GESTURE_EVENTS_DELEGATE:
+    private:
+    std::unique_ptr<GESTURE_EVENTS> gestures;
+    MOUSE_EVENTS * mouse;
+
+    template<MOUSE_EVENT GESTURE_EVENTS::*MEM>
+    class event_delegate:
+      private:
+      GESTURE_EVENTS_DELEGATE * parent;
+
+      MOUSE_EVENT & get():
+        if !parent->gestures:
+          parent->gestures = std::make_unique<GESTURE_EVENTS>()
+          parent->gestures->attach(parent->mouse)
+        return (*parent->gestures).*MEM
+
+      public:
+      void operator+=(std::function<void(input::SynMotionEvent &)> f):
+        get() += f
+
+      void clear():
+        if parent->gestures:
+          get().clear()
+
+      bool empty():
+        return !parent->gestures || get().empty()
+    ;
+
+    public:
+    GESTURE_EVENTS_DELEGATE(MOUSE_EVENTS * mouse): mouse(mouse):
+      pass
+
+    event_delegate<&GESTURE_EVENTS::long_press>   long_press   = { this }
+    event_delegate<&GESTURE_EVENTS::single_click> single_click = { this }
+    event_delegate<&GESTURE_EVENTS::double_click> double_click = { this }
+    event_delegate<&GESTURE_EVENTS::drag_start>   drag_start   = { this }
+    event_delegate<&GESTURE_EVENTS::dragging>     dragging     = { this }
+    event_delegate<&GESTURE_EVENTS::drag_end>     drag_end     = { this }
+  ;

--- a/src/rmkit/ui/events.cpy
+++ b/src/rmkit/ui/events.cpy
@@ -32,9 +32,11 @@ namespace ui:
     MOUSE_EVENT dragging
     MOUSE_EVENT drag_end
 
-    // The threshold area that determines if this is a touch-based gesture
-    // (e.g. long_press, double_click) or a motion-based gesture (e.g. drag).
-    int touch_slop_size = 50
+    // The threshold that determines if this is a touch-based gesture (e.g.
+    // long_press, double_click) or a motion-based gesture (e.g. drag). For
+    // touch-based gestures, the x and y deltas are always < this value; once
+    // the x or y delta > this value, it is considered a motion-based gesture.
+    int touch_threshold = 50
 
     // Once dragging, only submit events when the x or y delta > this step.
     // This limits the number of dragging events.
@@ -105,7 +107,7 @@ namespace ui:
         }, double_click_timeout)
 
     inline void DOWN_move(input::SynMotionEvent &ev):
-      if outside_tolerance(ev, touch_slop_size):
+      if outside_tolerance(ev, touch_threshold):
         state = DRAGGING
         cancel_long_press()
         drag_start(prev_ev)

--- a/src/rmkit/ui/events.cpy
+++ b/src/rmkit/ui/events.cpy
@@ -142,7 +142,7 @@ namespace ui:
         single_click_timer = nullptr
 
     bool outside_tolerance(const input::SynMotionEvent & ev, int tolerance):
-     return std::abs(ev.x - prev_ev.x) > tolerance || std::abs(ev.y - prev_ev.y) > tolerance
+      return std::abs(ev.x - prev_ev.x) > tolerance || std::abs(ev.y - prev_ev.y) > tolerance
   ;
 
   class GESTURE_EVENTS_DELEGATE:

--- a/src/rmkit/ui/events.cpy
+++ b/src/rmkit/ui/events.cpy
@@ -108,7 +108,8 @@ namespace ui:
       if outside_tolerance(ev, touch_slop_size):
         state = DRAGGING
         cancel_long_press()
-        drag_start(ev)
+        drag_start(prev_ev)
+        prev_ev = ev
 
     inline void WAIT_DOUBLE_CLICK_down(input::SynMotionEvent &ev):
       state = SECOND_DOWN

--- a/src/rmkit/ui/widget.cpy
+++ b/src/rmkit/ui/widget.cpy
@@ -1,25 +1,9 @@
+#include "events.h"
 #include "style.h"
 #include "../fb/fb.h"
 #include "../util/signals.h"
 
 namespace ui:
-  PLS_DEFINE_SIGNAL(MOUSE_EVENT, input::SynMotionEvent)
-  class MOUSE_EVENTS:
-    public:
-    MOUSE_EVENT enter
-    MOUSE_EVENT leave
-    MOUSE_EVENT down
-    MOUSE_EVENT up
-    MOUSE_EVENT click
-    MOUSE_EVENT hover
-    MOUSE_EVENT move
-  ;
-
-  PLS_DEFINE_SIGNAL(KEY_EVENT, input::SynKeyEvent)
-  class KEY_EVENTS:
-    public:
-    KEY_EVENT pressed
-  ;
   // Class: ui::Widget
   //
   // The widget class is the base of all other widgets. A widget is typically
@@ -35,6 +19,7 @@ namespace ui:
     vector<shared_ptr<Widget>> children
 
     MOUSE_EVENTS mouse
+    GESTURE_EVENTS_DELEGATE gesture = { &mouse }
     KEY_EVENTS kbd
 
     // variables: x, y, w, h

--- a/src/rmkit/ui/widget.cpy
+++ b/src/rmkit/ui/widget.cpy
@@ -19,7 +19,7 @@ namespace ui:
     vector<shared_ptr<Widget>> children
 
     MOUSE_EVENTS mouse
-    GESTURE_EVENTS_DELEGATE gesture = { &mouse }
+    GESTURE_EVENTS_DELEGATE gestures = { &mouse }
     KEY_EVENTS kbd
 
     // variables: x, y, w, h

--- a/src/rmkit/util/signals.cpy
+++ b/src/rmkit/util/signals.cpy
@@ -37,6 +37,9 @@ namespace PLS:
     void clear():
       cbs.clear()
 
+    bool empty():
+      return cbs.empty()
+
   template<typename T>
   class Observable:
     T value


### PR DESCRIPTION
First draft of drag and long-click events. A couple thoughts:

Naming might be confusing, since there's already a global Gesture class (edit: but then, "gesture" does seem to be the standard term: see for instance Android's [GestureDetector](https://developer.android.com/training/gestures/detector) which has a lot of similarities w/ this approach). Feedback very welcome.

There's some redundancy with `short_click` and `click`, but they mean slightly different things, which is probably confusing. `click` just means "the mouse was down in this widget, and now it's up", but `short_click` means "down and up within a 50-pixel area, and within 0.5 seconds". Those values are configurable of course, but it's a more specific -- maybe too specific -- idea of what "click" means.

I thought about sticking the events under the MouseGestureManager instead of having them directly in MOUSE_EVENTS. Maybe that would make it clear that these aren't raw/simple events, but are pre-processed events. Maybe the interface actually looks like `widget->gesture->drag_start` even, instead of `widget->mouse.drag_start`. Or perhaps there's a way to hide the creation of the GestureManager in a function call, like `widget->gesture().drag_start`.

I haven't dealt with capture yet, but I don't think it'll be too hard. In my mind it makes the most sense to have ui::MainLoop::capture_widget, but I think that creates a circular dependency, so it might have to be ui::Widget::capture_widget.