### PR TITLE
[rmkit] increase fidelity of to_rgb8

### DIFF
--- a/src/rmkit/color.h
+++ b/src/rmkit/color.h
@@ -42,9 +42,9 @@ constexpr rgb_color to_rgb8(remarkable_color s)
 {
   #ifndef USE_GRAYSCALE_8BIT
     return {
-      uint8_t((s & 0xf800) >> 8),
-      uint8_t((s & 0x7e0) >> 3),
-      uint8_t((s & 0x1f) << 3)
+      uint8_t(((s & 0xf800) >> 11) / 31. * 255.),
+      uint8_t(((s & 0x7e0) >> 5) / 63. * 255.),
+      uint8_t((s & 0x1f) / 31. * 255.)
     };
   #endif
 


### PR DESCRIPTION
I tried this new code w/ my icon generation script and found that the whites weren't quite white. Using the previous algorithm, WHITE turns into 248, 252, 248 (f8fcf8), in the new one it's 255, 255, 255.