### PR TITLE
[rmkit] Add RMKIT_DEFAULT_FONT env var

### DIFF
--- a/src/rmkit/fb/stb_text.cpy
+++ b/src/rmkit/fb/stb_text.cpy
@@ -17,12 +17,14 @@ namespace stbtext:
 
   void setup_font():
     if !did_setup:
-      #ifdef REMARKABLE
-      const char *filename = "/usr/share/fonts/ttf/noto/NotoMono-Regular.ttf";
-     // TODO: fix the max size read to prevent overflows (or just abort on really large files)
-      #else
-      const char *filename = "src/vendor/NotoSansMono-Regular.ttf";
-      #endif
+      const char *filename = getenv("RMKIT_DEFAULT_FONT");
+      if filename == NULL:
+        #ifdef REMARKABLE
+        filename = "/usr/share/fonts/ttf/noto/NotoMono-Regular.ttf";
+       // TODO: fix the max size read to prevent overflows (or just abort on really large files)
+        #else
+        filename = "src/vendor/NotoSansMono-Regular.ttf";
+        #endif
       _ := fread(font_buffer, 1, 24<<20, fopen(filename, "rb"));
 
       stbtt_InitFont(&font, font_buffer, 0);

--- a/src/rmkit/fb/stb_text.cpy
+++ b/src/rmkit/fb/stb_text.cpy
@@ -25,7 +25,12 @@ namespace stbtext:
         #else
         filename = "src/vendor/NotoSansMono-Regular.ttf";
         #endif
-      _ := fread(font_buffer, 1, 24<<20, fopen(filename, "rb"));
+      FILE * file = fopen(filename, "rb");
+      if file == NULL:
+        cerr << "Unable to read font file: " << filename << endl;
+        return;
+      _ := fread(font_buffer, 1, 24<<20, file);
+      fclose(file);
 
       stbtt_InitFont(&font, font_buffer, 0);
       did_setup = true

--- a/src/rmkit/fb/stb_text.cpy
+++ b/src/rmkit/fb/stb_text.cpy
@@ -27,7 +27,7 @@ namespace stbtext:
         #endif
       FILE * file = fopen(filename, "rb");
       if file == NULL:
-        cerr << "Unable to read font file: " << filename << endl;
+        debug "Unable to read font file: ", filename
         return;
       _ := fread(font_buffer, 1, 24<<20, file);
       fclose(file);


### PR DESCRIPTION
Mostly adding this for resim builds, but I'm not attached to the idea or the name.