### PR TITLE
[lamp] Add drawing Arc, Bezier curve and Rounded rectangle

### DIFF
--- a/src/lamp/example.in
+++ b/src/lamp/example.in
@@ -5,3 +5,5 @@ pen circle 600 600 500 50
 pen circle 900 900 200 50
 pen circle 1100 1100 100 50
 pen circle 1200 1200 50 50
+pen roundedrectangle 900 1000 1300 1600 100
+pen bezier 700 200 1300 900 200 400 800 1700

--- a/src/lamp/main.cpy
+++ b/src/lamp/main.cpy
@@ -205,6 +205,16 @@ void pen_draw_rounded_rectangle(int x1, y1, x2, y2, r):
     y2 = pen_y
   debug "DRAWING ROUNDED RECT", x1, y1, x2, y2, r
   step:=10
+
+  if x2 < x1:
+    temp:=x1
+    x1=x2
+    x2=temp
+  if y2 < y1:
+    temp:=y1
+    y1=y2
+    y2=temp
+
   segmentx:=abs(x2-x1)
   segmenty:=abs(y2-y1)
   if (r > (0.5*segmentx))

--- a/src/lamp/main.cpy
+++ b/src/lamp/main.cpy
@@ -259,14 +259,6 @@ void pen_draw_bezier(vector<int> coors):
   trace_bezier(coors)
   act_on_line("pen up")
 
-void pen_draw_circle(int x1, y1, radius):
-  if radius <= 1:
-    debug "INVALID RADIUS FOR CIRCLE", radius
-    return
-
-  pass
-
-
 
 int touch_fd, pen_fd
 void act_on_line(string line):
@@ -299,11 +291,19 @@ void act_on_line(string line):
       ss >> ox >> oy >> x >> y
     else:
       debug "UNRECOGNIZED MOVE LINE", line, "REQUIRES 2 or 4 COORDINATES"
-  if action == "rectangle" || action == "line" || action == "circle":
+  if action == "rectangle" || action == "line":
     if len(tokens) == 6:
       ss >> ox >> oy >> x >> y
     else:
       debug "UNRECOGNIZED DRAW LINE", line, "REQUIRES 4 COORDINATES"
+  if action == "circle":
+    if len(tokens) == 6:
+      ss >> ox >> oy >> x >> y
+    else if len(tokens) == 5:
+      ss >> ox >> oy >> x
+      y = x
+    else:
+      debug "UNRECOGNIZED DRAW LINE", line, "REQUIRES 2 COORDINATES AND 1 OR 2 RADIUS"
   if action == "arc":
     if len(tokens) == 8:
       ss >> ox >> oy >> x >> y >> a1 >> a2

--- a/src/lamp/main.cpy
+++ b/src/lamp/main.cpy
@@ -207,61 +207,61 @@ void pen_draw_rounded_rectangle(int x1, y1, x2, y2, r):
   step:=10
 
   if x2 < x1:
-    temp:=x1
-    x1=x2
-    x2=temp
+    temp := x1
+    x1 = x2
+    x2 = temp
   if y2 < y1:
-    temp:=y1
-    y1=y2
-    y2=temp
+    temp := y1
+    y1 = y2
+    y2 = temp
 
-  segmentx:=abs(x2-x1)
-  segmenty:=abs(y2-y1)
-  if (r > (0.5*segmentx))
-    r=0.5*segmentx
-  if (r > (0.5*segmenty))
-    r=0.5*segmenty
+  segmentx := abs(x2 - x1)
+  segmenty := abs(y2 - y1)
+  if (r > (0.5 * segmentx))
+    r = 0.5 * segmentx
+  if (r > (0.5 * segmenty))
+    r = 0.5 * segmenty
 
-  pointx:=x1+segmentx-r
-  pointy:=y1+r
-  degreesx:=270
-  degreesy:=360
+  pointx := x1 + segmentx - r
+  pointy := y1 + r
+  degreesx := 270
+  degreesy := 360
   act_on_line("pen down " + to_string(pointx) + " " + to_string(y1))
   trace_arc(pointx, pointy, r, r, degreesx, degreesy, step)
-  pointx=x1+segmentx-r
-  pointy=y1+segmenty-r
-  degreesx=0
-  degreesy=90
+  pointx = x1 + segmentx - r
+  pointy = y1 + segmenty - r
+  degreesx = 0
+  degreesy = 90
   trace_arc(pointx, pointy, r, r, degreesx, degreesy, step)
-  pointx=x1+r
-  pointy=y1+segmenty-r
-  degreesx=90
-  degreesy=180
+  pointx = x1 + r
+  pointy = y1 + segmenty - r
+  degreesx = 90
+  degreesy = 180
   trace_arc(pointx, pointy, r, r, degreesx, degreesy, step)
-  pointx=x1+r
-  pointy=y1+r
-  degreesx=180
-  degreesy=270
+  pointx = x1 + r
+  pointy = y1 + r
+  degreesx = 180
+  degreesy = 270
   trace_arc(pointx, pointy, r, r, degreesx, degreesy, step)
 
-  pointx=x1+segmentx-r
+  pointx = x1 + segmentx - r
   act_on_line("pen move " + to_string(pointx) + " " + to_string(y1))
   act_on_line("pen up")
 
 void trace_bezier(vector<int> coors):
   double pointx, pointy
-  step:=0.01
+  step := 0.01
   if (len(coors) == 6):
-    for t:=step; t<=1.0+step; t=t+step:
-      it:=1-t
-      pointx = it*it*coors[0] + 2*t*it*coors[2] + t*t*coors[4];
-      pointy = it*it*coors[1] + 2*t*it*coors[3] + t*t*coors[5];
+    for t := step; t <= (1.0 + step); t = t + step:
+      it := 1 - t
+      pointx = it * it * coors[0] + 2 * t * it * coors[2] + t * t * coors[4];
+      pointy = it * it * coors[1] + 2 * t * it * coors[3] + t * t * coors[5];
       act_on_line("fastpen move " + to_string(int(pointx)) + " " + to_string(int(pointy)))
   else if (len(coors) == 8)
-    for t:=step; t<=1.0+step; t=t+step:
-      it:=1-t
-      pointx = it*it*it*coors[0] + 3*t*it*it*coors[2] + 3*t*t*it*coors[4] + t*t*t*coors[6];
-      pointy = it*it*it*coors[1] + 3*t*it*it*coors[3] + 3*t*t*it*coors[5] + t*t*t*coors[7];
+    for t := step; t <= (1.0 + step); t = t + step:
+      it := 1 - t
+      pointx = it * it * it * coors[0] + 3 * t * it * it * coors[2] + 3 * t * t * it * coors[4] + t * t * t * coors[6];
+      pointy = it * it * it * coors[1] + 3 * t * it * it * coors[3] + 3 * t * t * it * coors[5] + t * t * t * coors[7];
       act_on_line("fastpen move " + to_string(int(pointx)) + " " + to_string(int(pointy)))
 
 void pen_draw_bezier(vector<int> coors):
@@ -313,7 +313,7 @@ void act_on_line(string line):
       ss >> ox >> oy >> x
       y = x
     else:
-      debug "UNRECOGNIZED DRAW LINE", line, "REQUIRES 2 COORDINATES AND 1 OR 2 RADIUS"
+      debug "UNRECOGNIZED DRAW CIRCLE", line, "REQUIRES 2 COORDINATES AND 1 OR 2 RADIUS"
   if action == "arc":
     if len(tokens) == 8:
       ss >> ox >> oy >> x >> y >> a1 >> a2

--- a/src/lamp/main.cpy
+++ b/src/lamp/main.cpy
@@ -178,7 +178,7 @@ void pen_draw_circle(int ox, oy, r1, r2):
   act_on_line("pen down " + to_string(int(ox + r1)) + " " + to_string(int(oy)))
   old_move_pts := move_pts
   move_pts = 10
-  trace_arc(ox, oy, r1, r2, 0, 360, 10)
+  trace_arc(ox, oy, r1, r2, 0, 360, 1)
   move_pts = old_move_pts
   act_on_line("pen up")
 


### PR DESCRIPTION
Syntax:
- Arc: `pen arc start_x start_y end_x end_y start_angle end_angle`
Angles are in degree. Circle drawing function was also modified to use 0-360 degree arc drawing function.
- Bezier:
    - `pen bezier start_x start_y control_x control_y end_x end_y` 
    - `pen bezier start_x start_y control1_x control1_y control2_x control2_y end_x end_y`
- Rounded rectangle: `pen roundedrectangle start_x start_y end_x end_y radius`

![2021-02-17T220527 307](https://user-images.githubusercontent.com/26436809/108202042-469c7f00-716c-11eb-987d-4768ebba5b66.png)
