### PR TITLE
[rmkit] Allow drag events after long_press

### DIFF
--- a/src/input_demo/main.cpy
+++ b/src/input_demo/main.cpy
@@ -18,7 +18,8 @@ class GestureWidget : public ui::Widget:
     // drag events
     gestures.drag_start += PLS_LAMBDA(auto & ev) {
       debug "DRAG START"
-      fill = GRAY
+      if ev.is_long_press:
+        fill = GRAY
       drag_x = ev.x - square_x
       drag_y = ev.y - square_y
       dirty = 1


### PR DESCRIPTION
Turns out there are some puzzles that have special behavior for _right_ click and drag, which is what long_press and drag would simulate.

In the original widget gesture PR I made a point to stop processing events after long_press was detected, so we didn't end up with a weird situation like down + timeout + up triggering both long_press and single_click. But there's a fairly straightforward way to get long_press + drag: add a new state (LONG_DOWN) and then allow transitioning from LONG_DOWN -> DRAGGING, but ignore any up events in LONG_DOWN.