### PR TITLE
Add sleep action

### DIFF
--- a/src/lamp/main.cpy
+++ b/src/lamp/main.cpy
@@ -18,7 +18,7 @@ using namespace std
 int offset = 0
 int move_pts = 500
 double denom = 360/(2*3.14)
-
+bool bsleep = false
 
 rm_version := util::get_remarkable_version()
 
@@ -387,6 +387,19 @@ void act_on_line(string line):
         write_events(touch_fd, finger_move(finger_x, finger_y, x, y))
       finger_x = x
       finger_y = y
+    else:
+      debug "UNKNOWN ACTION", action, "IN", line
+  else if tool == "sleep":
+    int val = strtol(action.c_str(), NULL, 10) 
+    if action == "on"
+      bsleep = true
+    else if action == "off"
+      bsleep = false
+    else if bsleep == false:
+      pass
+    else if 1 <= val && val <= 10000:
+      usleep(val * 1000)
+      debug "SLEEP FOR" val "ms"
     else:
       debug "UNKNOWN ACTION", action, "IN", line
   else:


### PR DESCRIPTION
New action sleep defined with

sleep on | off | 1 < <int> < 10000

sleep time is presented in ms
debug message informs user that a long sleep does not mean lamp hangs or crashed
with on | off users can globally switch the sleep command on or off for the following sleep commands

example:
pen line 0 0 100 100
sleep on
sleep 1000
pen line 100 100 200 200
sleep 1000
sleep off
pen line 200 200 300 300
sleep 1000 # this will not be executed
pen line 300 300 400 400