### PR TITLE
[fb] add update_mode option

### DIFF
--- a/src/rmkit/fb/fb.cpy
+++ b/src/rmkit/fb/fb.cpy
@@ -74,6 +74,7 @@ namespace framebuffer:
     int byte_size = 0, dirty = 0
     int update_marker = 1
     int waveform_mode = WAVEFORM_MODE_DU
+    int update_mode = UPDATE_MODE_PARTIAL
     DITHER::MODE dither = DITHER::NONE
 
     RESIZE_EVENT resize
@@ -659,11 +660,12 @@ namespace framebuffer:
       update_data.update_marker = 0
       update_data.update_region = update_rect
       update_data.waveform_mode = self.waveform_mode
-      update_data.update_mode = UPDATE_MODE_PARTIAL
+      update_data.update_mode = self.update_mode
       update_data.dither_mode = EPDC_FLAG_EXP1
       update_data.temp = TEMP_USE_REMARKABLE_DRAW
       update_data.flags = 0
       self.waveform_mode = WAVEFORM_MODE_DU
+      self.update_mode = UPDATE_MODE_PARTIAL
 
       if update_rect.height == 0 || update_rect.width == 0:
         return um


### PR DESCRIPTION
I'm working on dealing with ghosting, and the only thing I've gotten to work is using UPDATE_MODE_FULL with WAVEFORM_MODE_GC16. This makes `fb->redraw_screen(true)` use UPDATE_MODE_FULL.

There are three places I could find that would trigger this code path in rmkit currently:
* remux [App::on_suspend()](https://github.com/rmkit-dev/rmkit/blob/8bd470563412b8526eb901da98380b6df846f3ac/src/remux/launcher.cpy#L571)
* remux [AppBackground::render()](https://github.com/rmkit-dev/rmkit/blob/8bd470563412b8526eb901da98380b6df846f3ac/src/remux/launcher.cpy#L125)
* iago [AppBackground::render()](https://github.com/rmkit-dev/rmkit/blob/8bd470563412b8526eb901da98380b6df846f3ac/src/iago/main.cpy#L31)


^^ I don't know enough about how those are supposed to work to say if using UPDATE_MODE_FULL is appropriate in those places. If not, I'm also happy to do something like add `fb::update_mode` as a companion to `fb::waveform_mode`.