### PR TITLE
[ui] Add TextDropdown::autosize_options

### DIFF
--- a/src/rmkit/ui/dropdown.cpy
+++ b/src/rmkit/ui/dropdown.cpy
@@ -127,7 +127,7 @@ namespace ui:
         self.scene = ui::make_scene()
         y_off := self.option_y
         if dir == DIRECTION::DOWN:
-          y_off = y - self.option_y
+          y_off = y + self.option_y
         layout := VerticalLayout(x + self.option_x, y_off, ow, height, self.scene)
 
         i := 0


### PR DESCRIPTION
Adds a method to automatically calculate the size of a dropdown's options. This is generally only useful for calculating the option width.