### PR TITLE
[ui] Add ui::DropdownMenu

### DIFF
--- a/src/input_demo/main.cpy
+++ b/src/input_demo/main.cpy
@@ -92,6 +92,22 @@ class App:
     h_layout2.pack_center(new ui::Text(0, 0, 200, 50, "Hello world"))
     h_layout3.pack_end(new ui::Text(0, 0, 200, 50, "Hello world"))
 
+    // Couple of demo menus
+    menu2 := new ui::DropdownMenu(0, 0, 200, 50, "Menu 2")
+    menu2->add_section("Hello world")
+    menu2->add_options({"Option D", "Option E", "Option F", "Very very very very long option"})
+    h_layout1.pack_end(menu2)
+    menu2->events.selected += PLS_LAMBDA(int idx):
+      debug "MENU 2 SELECTED", idx, menu2->options[idx]->name
+    ;
+
+    menu1 := new ui::DropdownMenu(0, 0, 200, 50, "Menu 1")
+    menu1->add_options({"Option A", "Option B", "Option C"})
+    h_layout1.pack_end(menu1)
+    menu1->events.selected += PLS_LAMBDA(int idx):
+      debug "MENU 1 SELECTED", idx, menu1->options[idx]->name
+    ;
+
     h_layout := ui::HorizontalLayout(0, 0, w, h, demo_scene)
 
     v_layout.pack_start(h_layout)


### PR DESCRIPTION
A specialization of TextDropdown and DropdownButton for simple menus.

* Defaults to DIRECTION::DOWN
* The menu title is static; selections do not replace it
* Offsets options so they appear below the menu (instead of covering it)
* Auto-sizes options before they are shown

This adds a few features to dropdowns in general:
* New function TextDropdown::add_options, which adds options to the
  last-added section (or creates a blank section if none exists). This is
  a shortcut so you don't have to add a section if you don't need it.
* The option layout is shifted to the left if it would run off the
  screen.