### PR TITLE
Virtual widget destructor

### DIFF
--- a/src/harmony/main.cpy
+++ b/src/harmony/main.cpy
@@ -10,13 +10,16 @@ using app_ui::STATE
 
 class ToolBar : public ui::HorizontalLayout:
   public:
+  class Background: public ui::Widget:
+    public:
+    Background(int x, y, w, h): ui::Widget(x, y, w, h):
+      pass
+    void render():
+      self.fb->draw_rect(x, y, w, h, WHITE, true /* fill */)
+  ;
+
   ToolBar(int x, y, w, h, ui::Scene s): ui::HorizontalLayout(x, y, w, h, s):
-    s->add(self)
-
-  void render():
-    self.fb->draw_rect(x, y, w, h, WHITE, true /* fill */)
-
-
+    s->add(new Background(x, y, w, h))
 ;
 
 class App:

--- a/src/minesweeper/main.cpy
+++ b/src/minesweeper/main.cpy
@@ -140,18 +140,18 @@ class Cell: public ui::Widget:
       self.textWidget->render()
 
     if opened && self.is_bomb && !self.flagged:
-      pixmap := ui::Pixmap(self.x+5, self.y+5, self.w-10, self.h-10, ICON(assets::bomb_solid_png))
+      ui::Pixmap pixmap(self.x+5, self.y+5, self.w-10, self.h-10, ICON(assets::bomb_solid_png))
       pixmap.render()
 
     if self.flagged && !opened:
-      pixmap := ui::Pixmap(self.x+5, self.y+5, self.w-20, self.h-20, ICON(assets::flag_solid_png))
+      ui::Pixmap pixmap(self.x+5, self.y+5, self.w-20, self.h-20, ICON(assets::flag_solid_png))
       pixmap.render()
 
     if self.flagged && opened && self.is_bomb:
-      pixmap := ui::Pixmap(self.x+5, self.y+5, self.w-10, self.h-10, ICON(assets::flag_bomb_solid_png))
+      ui::Pixmap pixmap(self.x+5, self.y+5, self.w-10, self.h-10, ICON(assets::flag_bomb_solid_png))
       pixmap.render()
     if self.question && !opened:
-      pixmap := ui::Pixmap(self.x+5, self.y+5, self.w-10, self.h-10, ICON(assets::question_solid_png))
+      ui::Pixmap pixmap(self.x+5, self.y+5, self.w-10, self.h-10, ICON(assets::question_solid_png))
       pixmap.render()
 
 
@@ -356,7 +356,7 @@ class HighScoreWidget: public ui::Widget:
     pass
 
   void render():
-    text := ui::Text(self.x, self.y, 800, 500, "under construction")
+    ui::Text text(self.x, self.y, 800, 500, "under construction")
     text.set_style(ui::Stylesheet().justify_center())
     text.render()
 

--- a/src/rmkit/ui/dialog.cpy
+++ b/src/rmkit/ui/dialog.cpy
@@ -119,11 +119,11 @@ namespace ui:
       a_layout.pack_start(self.titleWidget)
       a_layout.pack_start(self.contentWidget)
 
-      button_bar := new HorizontalLayout(0, 0, self.w, 50, self.scene)
+      button_bar := HorizontalLayout(0, 0, self.w, 50, self.scene)
       a_layout.pack_end(button_bar)
-      button_bar->y -= 2
+      button_bar.y -= 2
 
-      self.add_buttons(button_bar)
+      self.add_buttons(&button_bar)
 
     virtual void add_buttons(HorizontalLayout *button_bar):
       default_fs := ui::Style::DEFAULT.font_size

--- a/src/rmkit/ui/layouts.cpy
+++ b/src/rmkit/ui/layouts.cpy
@@ -4,13 +4,15 @@
 
 #define DEBUG_LAYOUT
 namespace ui:
-  class Layout: public Widget:
+  class Layout:
     public:
     Scene scene
     vector<shared_ptr<Widget>> children
     int padding = 0
+    int x, y, w, h
+    bool visible = true
 
-    Layout(int x, y, w, h, Scene s): Widget(x,y,w,h), scene(s):
+    Layout(int x, y, w, h, Scene s): x(x), y(y), w(w), h(h), scene(s):
       pass
 
     void add(Widget *w):
@@ -32,10 +34,6 @@ namespace ui:
       for auto ch : children:
         ch->dirty = 1
 
-    // Layouts generally don't receive events
-    bool ignore_event(input::SynMotionEvent &ev):
-      return true
-
   class AbsLayout: public Layout:
     public:
     AbsLayout(int x, y, w, h, Scene s): Layout(x,y,w,h,s):
@@ -49,8 +47,25 @@ namespace ui:
 
     virtual void pack_start(Widget *w, int padding=0):
       pass
+    virtual void pack_center(Widget *w):
+      pass
     virtual void pack_end(Widget *w, int padding=0):
       pass
+
+    virtual void pack_start(Layout &w, int padding=0):
+      pass
+    virtual void pack_center(Layout &l):
+      pass
+    virtual void pack_end(Layout &l, int padding=0):
+      pass
+
+    // Layout pointer overloads for backwards compatibility
+    void pack_start(Layout *l, int padding=0):
+      pack_start(*l, padding)
+    void pack_center(Layout *l):
+      pack_center(*l)
+    void pack_end(Layout *l, int padding=0):
+      pack_end(*l, padding)
 
   // class: ui::VerticalLayout
   // --- Prototype ---
@@ -62,6 +77,9 @@ namespace ui:
   // 
   class VerticalLayout: public AutoLayout:
     public:
+    using AutoLayout::pack_start
+    using AutoLayout::pack_center
+    using AutoLayout::pack_end
     // function: Constructor
     //
     // Parameters:
@@ -136,6 +154,9 @@ namespace ui:
   // pack_end and pack_center
   class HorizontalLayout: public AutoLayout:
     public:
+    using AutoLayout::pack_start
+    using AutoLayout::pack_center
+    using AutoLayout::pack_end
     // function: Constructor
     //
     // Parameters:

--- a/src/rmkit/ui/widget.cpy
+++ b/src/rmkit/ui/widget.cpy
@@ -46,6 +46,9 @@ namespace ui:
     Widget(int x,y,w,h): x(x), y(y), w(w), h(h), _x(x), _y(y), _w(w), _h(h):
       self.install_signal_handlers()
 
+    virtual ~Widget():
+      pass
+
     // function: set_style
     // parameters:
     //


### PR DESCRIPTION
The goal with this is fixing #112, although most of the code ends up being related to getting rid of Widget as a base class of Layout. I think ultimately this clarifies that Layout is intended to be used only for position, and is not supposed to be a widget itself, although there's one place in harmony (the toolbar) where it's being used as a widget. I changed it so that the widget-specific code is in another class (Background) that's added to the toolbar in the constructor.

I also found another leak in Dialog where the button_bar pointer is created and never destroyed, which was easy enough to fix.

To clarify the issue in #112, we're storing Widget * in Scene, which is mostly fine, since a lot of functions are virtual. But since the (default) destructor isn't virtual, when that Widget * is deleted, only the Widget destructor is called, but the subclass destructor never gets called. So for instance, Button never frees its textWidget. (the rest of this I'm less clear on) However, adding the Widget destructor means either (or both?) the default move and copy constructors can't be defined, which meant a lot of code doesn't compile.

. . . after I ran through all this, I did at least figure out that the main reason those constructors couldn't be defined is b/c of the unique_ptr in GESTURE_EVENT_DELEGATE, so there is a much simpler solution that I've added in [another branch](https://github.com/rmkit-dev/rmkit/compare/master...mrichards42:virtual-widget-destructor-2) -- make that a shared_ptr, and voila, at least the default copy constructor is valid again (since shared_ptr can be copied, but unique_ptr can't).

Ultimately I think this branch is better since (a) I think Layout is better not as a widget, and (b) I think Widget should generally be heap allocated and shouldn't be copied. But I'm also open to using the other simpler branch if you'd prefer since it's pretty minimal and should require a lot less testing.