### PR TITLE
[fb] Support bitmaps with an alpha channel

### DIFF
--- a/src/rmkit/fb/fb.cpy
+++ b/src/rmkit/fb/fb.cpy
@@ -331,7 +331,7 @@ namespace framebuffer:
           if src[i] != alpha:
             if image.channels == 4:
               // 4th bit is alpha -- if it's 0, skip drawing
-              if ((char*)src)[r*i+3] != 0:
+              if ((char*)src)[4*i+3] != 0:
                 self._set_pixel(&ptr[i], i, j, to_rgb565((char *) src, i*image.channels))
             else if image.channels >= 3:
               self._set_pixel(&ptr[i], i, j, to_rgb565((char *) src, i*image.channels))

--- a/src/rmkit/fb/fb.cpy
+++ b/src/rmkit/fb/fb.cpy
@@ -331,7 +331,7 @@ namespace framebuffer:
           if src[i] != alpha:
             if image.channels == 4:
               // 4th bit is alpha -- if it's 0, skip drawing
-              if ((char*)src)[4*i+3] != 0:
+              if ((char*)src)[i*image.channels+3] != 0:
                 self._set_pixel(&ptr[i], i, j, to_rgb565((char *) src, i*image.channels))
             else if image.channels >= 3:
               self._set_pixel(&ptr[i], i, j, to_rgb565((char *) src, i*image.channels))

--- a/src/rmkit/fb/fb.cpy
+++ b/src/rmkit/fb/fb.cpy
@@ -329,6 +329,10 @@ namespace framebuffer:
             break
 
           if src[i] != alpha:
+            if image.channels == 4:
+              // 4th bit is alpha -- if it's 0, skip drawing
+              if ((char*)src)[r*i+3] != 0:
+                self._set_pixel(&ptr[i], i, j, to_rgb565((char *) src, i*image.channels))
             if image.channels >= 3:
               self._set_pixel(&ptr[i], i, j, to_rgb565((char *) src, i*image.channels))
             else if image.channels == 1:

--- a/src/rmkit/fb/fb.cpy
+++ b/src/rmkit/fb/fb.cpy
@@ -333,7 +333,7 @@ namespace framebuffer:
               // 4th bit is alpha -- if it's 0, skip drawing
               if ((char*)src)[r*i+3] != 0:
                 self._set_pixel(&ptr[i], i, j, to_rgb565((char *) src, i*image.channels))
-            if image.channels >= 3:
+            else if image.channels >= 3:
               self._set_pixel(&ptr[i], i, j, to_rgb565((char *) src, i*image.channels))
             else if image.channels == 1:
               grayscale_to_rgb32(src[i], src_val)


### PR DESCRIPTION
I have some pngs with transparency, and if I load them into a 4-channel image, the alpha channel is preserved. This doesn't get us alpha blending, but it at least lets us use the actual alpha channel on the image.