### PR TITLE
Add snapping

### DIFF
--- a/src/iago/main.cpy
+++ b/src/iago/main.cpy
@@ -34,8 +34,8 @@ class AppBackground: public ui::Widget:
 
 class SettingsDialog: public ui::ConfirmationDialog:
   public:
+  ui::ToggleButton* snap_enabled
   ui::RangeInput* snap_range
-  ui::ToggleButton* misc_toggle
 
   SettingsDialog(int x, y, w, h): ui::ConfirmationDialog(x, y, w, h):
     self.set_title(string("Settings"))
@@ -44,9 +44,8 @@ class SettingsDialog: public ui::ConfirmationDialog:
   void on_button_selected(string text):
     if text == "OK":
       ui::MainLoop::hide_overlay()
-      snap_val := self.snap_range->get_value()
-      shape::Shape::snapping = snap_val
-      debug "SET SNAPPING TO", snap_val
+      shape::Shape::set_snapping(self.snap_range->get_value())
+      shape::Shape::snap_enabled = self.snap_enabled->toggled
 
     if text == "CANCEL":
       ui::MainLoop::hide_overlay()
@@ -55,21 +54,31 @@ class SettingsDialog: public ui::ConfirmationDialog:
   // and packings for the modal overlay
   void build_dialog():
     ui::ConfirmationDialog::build_dialog()
-    style := ui::Stylesheet() \
-      .valign(ui::Style::VALIGN::MIDDLE) \
-      .justify(ui::Style::JUSTIFY::LEFT)
 
     a_layout := ui::VerticalLayout(self.x, self.y+50, self.w, self.h-100, self.scene)
 
-    snap_label := new ui::Text(10, 10, self.w - 20, 50, "snap to grid")
-    self.snap_range = new ui::RangeInput(10, 0, self.w - 20, 50)
-    self.misc_toggle = new ui::ToggleButton(10, 10, self.w - 20, 50, "Toggled")
-    self.misc_toggle->set_style(style)
+    snap_section_label := new ui::Text(10, 0, self.w - 20, 50, "Snapping")
+    snap_section_label->set_style(ui::Stylesheet()
+      .valign_bottom()
+      .justify_center()
+      .underline())
 
-    snap_range->set_range(0, 5)
-    a_layout.pack_start(snap_label)
+    self.snap_enabled = new ui::ToggleButton(10, 0, self.w - 20, 50, "Enabled")
+    self.snap_enabled->set_style(ui::Stylesheet()
+      .valign_middle()
+      .justify_left())
+
+    snap_range_label := new ui::Text(10, 0, self.w - 20, 50, "Snap grid (mm)")
+    snap_range_label->set_style(ui::Stylesheet()
+      .valign_bottom()
+      .justify_left())
+    self.snap_range = new ui::RangeInput(10, 0, self.w - 20, 50)
+    snap_range->set_range(1, 10)
+
+    a_layout.pack_start(snap_section_label)
+    a_layout.pack_start(snap_enabled)
+    a_layout.pack_start(snap_range_label)
     a_layout.pack_start(snap_range)
-    a_layout.pack_start(misc_toggle)
 
 
 

--- a/src/iago/main.cpy
+++ b/src/iago/main.cpy
@@ -35,12 +35,11 @@ class AppBackground: public ui::Widget:
 class SettingsDialog: public ui::ConfirmationDialog:
   public:
   ui::RangeInput* snap_range
+  ui::ToggleButton* misc_toggle
+
   SettingsDialog(int x, y, w, h): ui::ConfirmationDialog(x, y, w, h):
     self.set_title(string("Settings"))
     self.contentWidget = new ui::Text(0, 0, 20, 50, "")
-
-  void on_mouse_clicked(auto &ev):
-      ev.stop_propagation()
 
   void on_button_selected(string text):
     if text == "OK":
@@ -64,9 +63,14 @@ class SettingsDialog: public ui::ConfirmationDialog:
 
     snap_label := new ui::Text(10, 10, self.w - 20, 50, "snap to grid")
     self.snap_range = new ui::RangeInput(10, 0, self.w - 20, 50)
+    self.misc_toggle = new ui::ToggleButton(10, 10, self.w - 20, 50, "Toggled")
+    self.misc_toggle->set_style(style)
+
     snap_range->set_range(0, 5)
     a_layout.pack_start(snap_label)
     a_layout.pack_start(snap_range)
+    a_layout.pack_start(misc_toggle)
+
 
 
 class App:

--- a/src/iago/shapes.cpy
+++ b/src/iago/shapes.cpy
@@ -2,7 +2,9 @@
 #include "../build/rmkit.h"
 #include "../shared/string.h"
 
-const double MILLIMETER = 8.9333333333
+// display height from 261.62mm diagonal (10.3 inch) and 4:3 ratio,
+// seems to be quite accurate...
+const double MILLIMETER = 1872/209.296
 
 namespace shape:
   class DragHandle: public ui::Widget:

--- a/src/iago/shapes.cpy
+++ b/src/iago/shapes.cpy
@@ -1,3 +1,4 @@
+#include <cmath>
 #include "../build/rmkit.h"
 #include "../shared/string.h"
 
@@ -29,6 +30,10 @@ namespace shape:
     public:
     string name;
     DragHandle *handle_one, *handle_two
+
+    const double snapping = 44.6666666667 // 5mm
+    tuple<int, int> last_move_snap = tuple<int, int>(0, 0)
+
     Shape(int x, y, w, h, ui::Scene scene) : ui::Widget(x, y, w, h):
       scene->add(self)
       shape::to_draw.push_back(self)
@@ -37,10 +42,21 @@ namespace shape:
     Shape() : ui::Widget(x, y, w, h):
       return
 
+    int snap_position(int position):
+      return snapping * round(position / snapping)
+
+    void snap_handle(ui::Widget *handle):
+      if snapping != 0:
+        x, y := get_handle_coords(handle)
+        handle->x = snap_position(x) - handle->w/2
+        handle->y = snap_position(y) - handle->h/2
+
     void add_drag_handles(ui::Scene scene):
       sz := 25
       handle_one = new DragHandle(x, y, sz, sz)
       handle_two = new DragHandle(x+w, y+h, sz, sz)
+      snap_handle(handle_one)
+      snap_handle(handle_two)
       handle_two->set_shape(1)
 
       scene->add(handle_one)
@@ -64,7 +80,7 @@ namespace shape:
         handle_two->x += dx
         handle_two->y += dy
 
-        draw_pixel(handle_one)
+        draw_movement(handle_one)
       }
 
       handle_two->mouse.move += PLS_LAMBDA(auto &ev) {
@@ -75,11 +91,20 @@ namespace shape:
 
         handle_two->x = ev.x - handle_two->w/2
         handle_two->y = ev.y - handle_two->h/2
-        draw_pixel(handle_two)
+        draw_movement(handle_two)
       }
 
-      handle_one->mouse.up += PLS_DELEGATE(self.redraw)
-      handle_two->mouse.up += PLS_DELEGATE(self.redraw)
+      handle_one->mouse.up += PLS_LAMBDA(auto &ev) {
+        snap_handle(handle_one)
+        snap_handle(handle_two)
+        self->redraw(ev)
+      }
+
+      handle_two->mouse.up += PLS_LAMBDA(auto &ev) {
+        snap_handle(handle_two)
+        self->redraw(ev)
+      }
+
       handle_one->mouse.leave += PLS_DELEGATE(self.redraw)
       handle_two->mouse.leave += PLS_DELEGATE(self.redraw)
 
@@ -89,8 +114,22 @@ namespace shape:
     void redraw(bool skip_shape=false):
       ui::MainLoop::full_refresh()
 
+    void draw_movement(ui::Widget *w1):
+      if snapping == 0:
+        draw_pixel(w1)
+      else:
+        x, y := get_handle_coords(w1)
+        x = snap_position(x)
+        y = snap_position(y)
+        last_x, last_y := self->last_move_snap
+        if x != last_x || y != last_y:
+          fb->draw_line(x-1, y-1, x+1, y+1, 3, BLACK)
+          fb->draw_line(last_x-1, last_y-1, last_x+1, last_y+1, 3, WHITE)
+          self->last_move_snap = tuple<int, int>(x, y)
+
     void draw_pixel(ui::Widget *w1):
-      fb->draw_line(w1->x+w1->w/2-1, w1->y+w1->h/2-1, w1->x+w1->w/2+1, w1->y+w1->h/2+1, 3, color::GRAY_9)
+      x, y := get_handle_coords(w1)
+      fb->draw_line(x-1, y-1, x+1, y+1, 3, color::GRAY_9)
 
     tuple<int, int> get_handle_coords(ui::Widget *w1)
       return (w1->x + w1->w/2), (w1->y + w1->h/2)

--- a/src/iago/shapes.cpy
+++ b/src/iago/shapes.cpy
@@ -31,7 +31,7 @@ namespace shape:
     string name;
     DragHandle *handle_one, *handle_two
 
-    const double snapping = 44.6666666667 // 5mm
+    static double snapping
     tuple<int, int> last_move_snap = tuple<int, int>(0, 0)
 
     Shape(int x, y, w, h, ui::Scene scene) : ui::Widget(x, y, w, h):
@@ -139,6 +139,10 @@ namespace shape:
 
     virtual void render():
       return
+  // stupid static initializers
+  double Shape::snapping = 44.6666666667 // 5mm
+
+
 
   class Line : public Shape:
     public:

--- a/src/rmkit/ui/button.cpy
+++ b/src/rmkit/ui/button.cpy
@@ -122,3 +122,31 @@ namespace ui:
 
   int Button::key_ctr = 16 // "q"
   Stylesheet Button::DEFAULT_STYLE = Stylesheet().justify_center()
+
+  class ToggleButton: public ui::Button:
+    public:
+    PLS_DEFINE_SIGNAL(TOGGLE_EVENT, int)
+    class TOGGLE_EVENTS:
+      public:
+      TOGGLE_EVENT toggled
+    ;
+    TOGGLE_EVENTS events
+
+    int toggled = false
+    ToggleButton(int x, y, w, h, string t): ui::Button(x,y,w,h,t):
+      pass
+
+    void before_render():
+      ui::Button::before_render()
+      if toggled:
+        self.textWidget->text = "[x] " + self.text 
+      else:
+        self.textWidget->text = "[ ] " + self.text 
+
+    void render():
+      ui::Button::render()
+
+    void on_mouse_click(input::SynMotionEvent &ev):
+      toggled = !toggled
+      self.events.toggled(toggled)
+      self.dirty = 1


### PR DESCRIPTION
- Support snapping on a (invisible) 1-10 millimeter grid
  When enabled, placement and movement of shapes/handles is restricted to common horizontal/vertical intervals of the 
  snapping value.  
- Add settings dialog with the snapping settings