### PR TITLE
Correct capitalized N and M in onscreen keyboard

### DIFF
--- a/src/rmkit/ui/keyboard.cpy
+++ b/src/rmkit/ui/keyboard.cpy
@@ -92,7 +92,7 @@ namespace ui:
       self.set_layout(
         "QWERTYUOIP",
         "ASDFGHJKL",
-        "ZXCVBnm"
+        "ZXCVBNM"
       )
 
     void number_layout():


### PR DESCRIPTION
Fix for #174 