### PR TITLE
Fix repo select in nao

### DIFF
--- a/src/nao/nao.sh
+++ b/src/nao/nao.sh
@@ -114,8 +114,7 @@ function SET() {
 
 function DISPLAY() {
     use_newline_separator
-    OUTPUT=`for line in ${SCENE[@]}; do echo $line; done`
-    RETURN=`echo "$OUTPUT" | ${SIMPLE}`
+    RETURN=`echo "${SCENE[*]}" | ${SIMPLE}`
     use_space_separator
     SAVED_RETURN=${RETURN}
 }


### PR DESCRIPTION
For some reason, looping through `${SCENE[@]}` was returning `1` for lines starting with `[button`