### PR TITLE
exit(0) if SIGINT or SIGTERM

### DIFF
--- a/src/rmkit/init.cpy
+++ b/src/rmkit/init.cpy
@@ -19,8 +19,8 @@ static void _rmkit_exit(int signum):
     case SIGINT:
       cerr << "received SIGINT, exiting" << endl;
       break
-    case SIGKILL:
-      cerr << "received SIGKILL, exiting" << endl;
+    case SIGTERM:
+      cerr << "received SIGTERM, exiting" << endl;
       break
     case SIGSEGV:
       cerr << "received SIGABRT, exiting" << endl;

--- a/src/rmkit/init.cpy
+++ b/src/rmkit/init.cpy
@@ -14,13 +14,16 @@ static void _rmkit_exit(int signum):
   fb := framebuffer::get()
   fb->cleanup()
   ui::MainLoop::in.ungrab()
-
+  exitCode = signum
+      
   switch signum:
     case SIGINT:
       cerr << "received SIGINT, exiting" << endl;
+      exitCode = 0
       break
     case SIGTERM:
       cerr << "received SIGTERM, exiting" << endl;
+      exitCode = 0
       break
     case SIGSEGV:
       cerr << "received SIGABRT, exiting" << endl;
@@ -30,7 +33,7 @@ static void _rmkit_exit(int signum):
       break
 
   ui::MainLoop::exit(signum)
-  exit(signum)
+  exit(exitCode)
 
 static void _rmkit_init() __attribute__((constructor))
 static void _rmkit_init():


### PR DESCRIPTION
The reason for this change is because SIGTERM and SIGINT are both external requests to exit the application, so exiting should not indicate that it was not successful.