### PR TITLE
Text improvements

### DIFF
--- a/src/rmkit/color.h
+++ b/src/rmkit/color.h
@@ -31,7 +31,9 @@ struct rgb_color {
 // 0(black) - 31(white)
 constexpr remarkable_color gray32(int n)
 {
-    return (n << 11) | (2*n << 5) | n;
+    //The green channel should have six bits, but 31 is only five. Set the last green bit unless n is zero
+    //otherwise white is actually slightly pink
+    return (n << 11) | (((2*n)|(n!=0))<< 5) | n;
 }
 
 // 0.0(black) - 1.0(white)

--- a/src/rmkit/fb/stb_text.cpy
+++ b/src/rmkit/fb/stb_text.cpy
@@ -141,7 +141,6 @@ namespace stbtext:
     for j = 0; j < image.h; j++:
       for i = 0; i < image.w; i++:
         uint32_t val = text_buffer[j*image.w+i]
-        //image.buffer[j*image.w+i] = val == 0 ? WHITE: BLACK;
         image.buffer[j*image.w+i] = color::gray32(31 - (val >> 3)); //rescale (0,255) to (31,0) to get gray tones
 
     // TODO: understand why we need to trim the top line

--- a/src/rmkit/fb/stb_text.cpy
+++ b/src/rmkit/fb/stb_text.cpy
@@ -141,7 +141,8 @@ namespace stbtext:
     for j = 0; j < image.h; j++:
       for i = 0; i < image.w; i++:
         uint32_t val = text_buffer[j*image.w+i]
-        image.buffer[j*image.w+i] = val == 0 ? WHITE: BLACK;
+        //image.buffer[j*image.w+i] = val == 0 ? WHITE: BLACK;
+        image.buffer[j*image.w+i] = color::gray32(31 - (val >> 3)); //rescale (0,255) to (31,0) to get gray tones
 
     // TODO: understand why we need to trim the top line
     // to get rid of artifacts above text


### PR DESCRIPTION
Improves the general appearance of text by rendering subpixels in shades of gray.

This required a fix to color::gray32. An off by one error made white render as 0xfffaff, which broke alpha rendering for text backgrounds that expected pure white.