### PR TITLE
single-header fixes

### DIFF
--- a/src/rmkit/fb/fb.cpy
+++ b/src/rmkit/fb/fb.cpy
@@ -1014,7 +1014,7 @@ namespace framebuffer:
       return um
 
 
-  static shared_ptr<FB> _FB
+  extern shared_ptr<FB> _FB = nullptr
 
   // function: framebuffer::get
   // this function returns the app's framebuffer

--- a/src/rmkit/fb/stb_text.cpy
+++ b/src/rmkit/fb/stb_text.cpy
@@ -20,8 +20,8 @@
 #define FONT_BUFFER_SIZE 24<<20
 namespace stbtext:
   // TODO: fix the max size read to prevent overflows (or just abort on really large files)
-  static unsigned char font_buffer[FONT_BUFFER_SIZE]
-  static stbtt_fontinfo font;
+  extern unsigned char font_buffer[FONT_BUFFER_SIZE] = {}
+  extern stbtt_fontinfo font = {}
   extern bool did_setup = false
   extern bool GRAYSCALE = false
 


### PR DESCRIPTION
I have *finally* figured out the issues preventing me from using the single-header rmkit across multiple TUs.

There were a few namespace-level global static variables. If such variables are not `extern` or `inline`, each TU will get their own uninitialized copy of the field.

This resulted in a build that throws no warnings at all, but segfaults at runtime when we try to read a null font, or the FB singleton is empty and we get no render.

I've used `extern` instead of `inline` because rmkit's build process complains about inline and there are already other fields with extern and that clever initializer generation. There should be no difference between the two, but inline is only in C++>=17

I think these were the only such fields left in rmkit. My application seems to work fine now with these changes.

I had to learn a lot about C++ to figure this out, so here's what I've got:
The only problems are namespace-level static variables and static variables within an inlined function. Static variables at the class/struct level work as you'd expect across TUs. Static and inline functions are also fine and work as expected, so long as they don't touch local static or namespace-static variables.